### PR TITLE
Proposed fix for issue 7

### DIFF
--- a/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
@@ -318,6 +318,9 @@ class AuditSubscriber implements EventSubscriber
         switch ($type->getName()) {
             case Type::BOOLEAN:
                 return $type->convertToPHPValue($value, $platform); // json supports boolean values
+            case Type::FLOAT:
+            case Type::DECIMAL:
+                return (string)$type->convertToDatabaseValue($value, $platform);
             default:
                 return $type->convertToDatabaseValue($value, $platform);
         }


### PR DESCRIPTION
Any case Type::FLOAT or Type::DECIMAL coming from frontend that is compared to the database value to check for differences differs in type. Usually a string vs float value is compared. This change casts these values to string to pass difference comparison if they're the same values but of different types. $type->convertToDatabaseValue does not do this.

Float precision may still cause differences. Even though the stored and provided value to the user may be the same. So it's a bit of a quick fix.