### PR TITLE
Add support for multiple firewalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ dh_doctrine_audit:
     table_suffix: '_audit'
 ```
 
+### Displaying firewall information
+
+The name of the firewall and the fully qualified class name of the User object is recorded, but is not displayed in the template by default. This can be useful in projects that use more than one firewall. Set `show_user_firewall` to `true` to enable the display of this data.
+
+```yaml
+// app/config/config.yml (symfony < 3.4)
+// config/dh_doctrine_audit.yaml (symfony >= 3.4)
+dh_doctrine_audit:
+    show_user_firewall: false
+```
+
 ### Creating audit tables
 
 Open a command console, enter your project directory and execute the

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -163,4 +163,14 @@ class AuditConfiguration
     {
         return $this->requestStack;
     }
+
+    /**
+     * Gets the value of firewallMap.
+     *
+     * @return FirewallMap
+     */
+    public function getFirewallMap(): FirewallMap
+    {
+        return $this->firewallMap;
+    }
 }

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -4,6 +4,7 @@ namespace DH\DoctrineAuditBundle;
 
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 
 class AuditConfiguration
 {
@@ -37,10 +38,16 @@ class AuditConfiguration
      */
     protected $requestStack;
 
-    public function __construct(array $config, TokenStorage $securityTokenStorage, RequestStack $requestStack)
+    /**
+     * @var FirewallMap
+     */
+    private $firewallMap;
+
+    public function __construct(array $config, TokenStorage $securityTokenStorage, RequestStack $requestStack, FirewallMap $firewallMap)
     {
         $this->securityTokenStorage = $securityTokenStorage;
         $this->requestStack = $requestStack;
+        $this->firewallMap = $firewallMap;
 
         $this->tablePrefix = $config['table_prefix'];
         $this->tableSuffix = $config['table_suffix'];

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -29,6 +29,11 @@ class AuditConfiguration
     private $entities = [];
 
     /**
+     * @var boolean
+     */
+    private $showUserFirewall;
+
+    /**
      * @var TokenStorage
      */
     protected $securityTokenStorage;
@@ -52,6 +57,7 @@ class AuditConfiguration
         $this->tablePrefix = $config['table_prefix'];
         $this->tableSuffix = $config['table_suffix'];
         $this->ignoredColumns = $config['ignored_columns'];
+        $this->showUserFirewall = $config['show_user_firewall'];
 
         if (isset($config['entities']) && !empty($config['entities'])) {
             // use entity names as array keys for easier lookup
@@ -172,5 +178,15 @@ class AuditConfiguration
     public function getFirewallMap(): FirewallMap
     {
         return $this->firewallMap;
+    }
+
+    /**
+     * Gets the value of showUserFirewall.
+     *
+     * @return bool
+     */
+    public function getShowUserFirewall(): bool
+    {
+        return $this->showUserFirewall;
     }
 }

--- a/src/DoctrineAuditBundle/AuditEntry.php
+++ b/src/DoctrineAuditBundle/AuditEntry.php
@@ -31,6 +31,14 @@ class AuditEntry
     /**
      * @var string
      */
+    protected $blame_user_fqcn;
+    /**
+     * @var string
+     */
+    protected $blame_user_firewall;
+    /**
+     * @var string
+     */
     protected $ip;
     /**
      * @var string
@@ -90,6 +98,22 @@ class AuditEntry
     public function getUsername(): string
     {
         return $this->blame_user ?? 'Unknown';
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUserFqcn(): ?string
+    {
+        return $this->blame_user_fqcn;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUserFirewall(): ?string
+    {
+        return $this->blame_user_firewall;
     }
 
     /**

--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Controller;
 
+use DH\DoctrineAuditBundle\AuditConfiguration;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -9,6 +10,16 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class AuditController extends Controller
 {
+    /**
+     * @var AuditConfiguration
+     */
+    private $auditConfiguration;
+
+    public function __construct(AuditConfiguration $auditConfiguration)
+    {
+        $this->auditConfiguration = $auditConfiguration;
+    }
+
     /**
      * @Method("GET")
      * @Template
@@ -37,6 +48,7 @@ class AuditController extends Controller
         return $this->render('DHDoctrineAuditBundle:Audit:entity_history.html.twig', [
             'entity' => $entity,
             'entries' => $entries,
+            'show_firewall_info' => $this->auditConfiguration->getSupportMultipleFirewalls(),
         ]);
     }
 

--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -2,7 +2,6 @@
 
 namespace DH\DoctrineAuditBundle\Controller;
 
-use DH\DoctrineAuditBundle\AuditConfiguration;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -11,11 +10,11 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AuditController extends Controller
 {
     /**
-     * @var AuditConfiguration
+     * @var array
      */
     private $auditConfiguration;
 
-    public function __construct(AuditConfiguration $auditConfiguration)
+    public function __construct(array $auditConfiguration)
     {
         $this->auditConfiguration = $auditConfiguration;
     }

--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -48,7 +48,7 @@ class AuditController extends Controller
         return $this->render('DHDoctrineAuditBundle:Audit:entity_history.html.twig', [
             'entity' => $entity,
             'entries' => $entries,
-            'show_firewall_info' => $this->auditConfiguration->getSupportMultipleFirewalls(),
+            'show_firewall_info' => $this->auditConfiguration['show_user_firewall'],
         ]);
     }
 

--- a/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
 
                 ->booleanNode('show_user_firewall')
-                    ->canBeUnset()
                     ->defaultFalse()
                 ->end()
             ->end()

--- a/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,11 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
+                ->booleanNode('show_user_firewall')
+                    ->canBeUnset()
+                    ->defaultFalse()
+                ->end()
             ->end()
         ;
 

--- a/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
@@ -313,6 +313,8 @@ class AuditSubscriber implements EventSubscriber
             'diffs' => ':diffs',
             'blame_id' => ':blame_id',
             'blame_user' => ':blame_user',
+            'blame_user_fqcn' => ':blame_user_fqcn',
+            'blame_user_firewall' => ':blame_user_firewall',
             'ip' => ':ip',
             'created_at' => ':created_at',
         ];
@@ -332,6 +334,8 @@ class AuditSubscriber implements EventSubscriber
         $statement->bindValue('diffs', json_encode($data['diff']));
         $statement->bindValue('blame_id', $data['blame']['user_id']);
         $statement->bindValue('blame_user', $data['blame']['username']);
+        $statement->bindValue('blame_user_fqcn', $data['blame']['user_fqcn']);
+        $statement->bindValue('blame_user_firewall', $data['blame']['user_firewall']);
         $statement->bindValue('ip', $data['blame']['client_ip']);
         $statement->bindValue('created_at', $dt->format('Y-m-d H:i:s'));
         $statement->execute();
@@ -484,6 +488,8 @@ class AuditSubscriber implements EventSubscriber
         $user_id = null;
         $username = null;
         $client_ip = null;
+        $user_fqcn = null;
+        $user_firewall = null;
 
         $request = $this->configuration->getRequestStack()->getCurrentRequest();
         if (null !== $request) {
@@ -496,6 +502,8 @@ class AuditSubscriber implements EventSubscriber
             if ($user instanceof UserInterface) {
                 $user_id = $user->getId();
                 $username = $user->getUsername();
+                $user_fqcn = \get_class($user);
+                $user_firewall = $this->configuration->getFirewallMap()->getFirewallConfig($request)->getName();
             }
         }
 
@@ -503,6 +511,8 @@ class AuditSubscriber implements EventSubscriber
             'user_id' => $user_id,
             'username' => $username,
             'client_ip' => $client_ip,
+            'user_fqcn' => $user_fqcn,
+            'user_firewall' => $user_firewall,
         ];
     }
 

--- a/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
@@ -82,6 +82,16 @@ class CreateSchemaListener implements EventSubscriber
             'notnull' => false,
             'length' => 100,
         ]);
+        $auditTable->addColumn('blame_user_fqcn', 'string', [
+            'default' => null,
+            'notnull' => false,
+            'length' => 255,
+        ]);
+        $auditTable->addColumn('blame_user_firewall', 'string', [
+            'default' => null,
+            'notnull' => false,
+            'length' => 100,
+        ]);
         $auditTable->addColumn('ip', 'string', [
             'default' => null,
             'notnull' => false,

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -1,6 +1,7 @@
 services:
-  class: DH\DoctrineAuditBundle\Controller\AuditController
-  arguments: ["%dh_doctrine_audit.configuration%"]
+  dh_doctrine_audit.controller:
+    class: DH\DoctrineAuditBundle\Controller\AuditController
+    arguments: ["%dh_doctrine_audit.configuration%"]
 
   dh_doctrine_audit.configuration:
     class: DH\DoctrineAuditBundle\AuditConfiguration

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -2,6 +2,7 @@ services:
   DH\DoctrineAuditBundle\Controller\AuditController:
     class: DH\DoctrineAuditBundle\Controller\AuditController
     arguments: ["%dh_doctrine_audit.configuration%"]
+    tags: ['controller.service_arguments']
 
   dh_doctrine_audit.configuration:
     class: DH\DoctrineAuditBundle\AuditConfiguration

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -1,4 +1,7 @@
 services:
+  class: DH\DoctrineAuditBundle\Controller\AuditController
+  arguments: ["%dh_doctrine_audit.configuration%"]
+
   dh_doctrine_audit.configuration:
     class: DH\DoctrineAuditBundle\AuditConfiguration
     arguments: ["%dh_doctrine_audit.configuration%", "@security.token_storage", "@request_stack", "@security.firewall.map"]

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -1,5 +1,5 @@
 services:
-  dh_doctrine_audit.controller:
+  DH\DoctrineAuditBundle\Controller\AuditController:
     class: DH\DoctrineAuditBundle\Controller\AuditController
     arguments: ["%dh_doctrine_audit.configuration%"]
 

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -1,7 +1,7 @@
 services:
   dh_doctrine_audit.configuration:
     class: DH\DoctrineAuditBundle\AuditConfiguration
-    arguments: ["%dh_doctrine_audit.configuration%", "@security.token_storage", "@request_stack"]
+    arguments: ["%dh_doctrine_audit.configuration%", "@security.token_storage", "@request_stack", "@security.firewall.map"]
     public: true
 
   dh_doctrine_audit.reader:

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -10,8 +10,10 @@
             <th>Object Id</th>
             <th>User Id</th>
             <th>Username</th>
-            <th>Firewall</th>
-            <th>Class</th>
+            {% if show_user_firewall %}
+                <th>Firewall</th>
+                <th>Class</th>
+            {% endif %}
             <th>IP</th>
             <th>Created At</th>
         </thead>
@@ -23,8 +25,10 @@
                 <td><a href="{{ path('dh_doctrine_audit_show_entity_history', { 'entity': entity, 'id': entry.getObjectId() }) }}">{{ entry.getObjectId() }}</a></td>
                 <td>{{ entry.getUserId() }}</td>
                 <td>{{ entry.getUsername() }}</td>
-                <td>{{ entry.getUserFirewall() }}</td>
-                <td>{{ entry.getUserFqcn() }}</td>
+                {% if show_firewall_info %}
+                    <td>{{ entry.getUserFirewall() }}</td>
+                    <td>{{ entry.getUserFqcn() }}</td>
+                {% endif %}
                 <td>{{ entry.getIp() }}</td>
                 <td>{{ entry.getCreatedAt() }}</td>
             </tr>

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -10,6 +10,8 @@
             <th>Object Id</th>
             <th>User Id</th>
             <th>Username</th>
+            <th>Firewall</th>
+            <th>Class</th>
             <th>IP</th>
             <th>Created At</th>
         </thead>
@@ -21,6 +23,8 @@
                 <td><a href="{{ path('dh_doctrine_audit_show_entity_history', { 'entity': entity, 'id': entry.getObjectId() }) }}">{{ entry.getObjectId() }}</a></td>
                 <td>{{ entry.getUserId() }}</td>
                 <td>{{ entry.getUsername() }}</td>
+                <td>{{ entry.getUserFirewall() }}</td>
+                <td>{{ entry.getUserFqcn() }}</td>
                 <td>{{ entry.getIp() }}</td>
                 <td>{{ entry.getCreatedAt() }}</td>
             </tr>


### PR DESCRIPTION
As mentioned in #13, I've extended this bundle to record the firewall's name and fully qualified class name of the `User` object when adding log entries. 

This was necessary for us as we use separate firewalls for public and admin users, and we wanted DoctrineAuditBundle to be able to audit changes to entities made by both 'types' of user.

This pull request adds these fields to the audit log entries and makes them visible in the Twig views.

If you'd prefer to turn this functionality on and off with some sort of configuration, I could look at doing that, but it has no adverse side effects if only one firewall is being used.