### PR TITLE
Use native Twig references for templates

### DIFF
--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -19,7 +19,7 @@ class AuditController extends Controller
         $reader = $this->container->get('dh_doctrine_audit.reader');
         $reader->getEntities();
 
-        return $this->render('DHDoctrineAuditBundle:Audit:audited_entities.html.twig', [
+        return $this->render('@DHDoctrineAudit/Audit/audited_entities.html.twig', [
             'audited' => $reader->getEntities(),
         ]);
     }
@@ -34,7 +34,7 @@ class AuditController extends Controller
         $reader = $this->container->get('dh_doctrine_audit.reader');
         $entries = $reader->getAudits($entity, $id, $page, $pageSize);
 
-        return $this->render('DHDoctrineAuditBundle:Audit:entity_history.html.twig', [
+        return $this->render('@DHDoctrineAudit/Audit/entity_history.html.twig', [
             'entity' => $entity,
             'entries' => $entries,
         ]);
@@ -50,7 +50,7 @@ class AuditController extends Controller
         $reader = $this->container->get('dh_doctrine_audit.reader');
         $data = $reader->getAudit($entity, $id);
 
-        return $this->render('DHDoctrineAuditBundle:Audit:entity_audit_details.html.twig', [
+        return $this->render('@DHDoctrineAudit/Audit/entity_audit_details.html.twig', [
             'entity' => $entity,
             'entry' => $data[0],
         ]);

--- a/src/DoctrineAuditBundle/Resources/views/Audit/audited_entities.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/audited_entities.html.twig
@@ -1,4 +1,4 @@
-{% extends "DHDoctrineAuditBundle::layout.html.twig" %}
+{% extends "@DHDoctrineAudit/layout.html.twig" %}
 
 {% block dh_doctrine_audit_content %}
     <h1>Audits ({{ audited|length }} entities)</h1>

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_audit_details.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_audit_details.html.twig
@@ -1,4 +1,4 @@
-{% extends "DHDoctrineAuditBundle::layout.html.twig" %}
+{% extends "@DHDoctrineAudit/layout.html.twig" %}
 
 {% macro dump(value, separator) %}
     {% import _self as audit_viewer %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -1,4 +1,4 @@
-{% extends "DHDoctrineAuditBundle::layout.html.twig" %}
+{% extends "@DHDoctrineAudit/layout.html.twig" %}
 
 {% block dh_doctrine_audit_content %}
     <h1>{{ entity }} history ({{ entries|length }} operations)</h1>


### PR DESCRIPTION
This makes the template compatible with projects disabling the Templating
component in recent Symfony versions and allow overwrite layout template