### PR TITLE
Support Symfony 4.2+

### DIFF
--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -3,9 +3,9 @@
 namespace DH\DoctrineAuditBundle\Controller;
 
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-class AuditController extends Controller
+class AuditController extends AbstractController
 {
     /**
      * @Route("/audit", name="dh_doctrine_audit_list_audits", methods={"GET"})


### PR DESCRIPTION
The "Symfony\Bundle\FrameworkBundle\Controller\Controller" class is deprecated since Symfony 4.2, use Symfony\Bundle\FrameworkBundle\Controller\AbstractController instead.