### PR TITLE
Allow non int obj

### DIFF
--- a/src/DoctrineAuditBundle/AuditEntry.php
+++ b/src/DoctrineAuditBundle/AuditEntry.php
@@ -13,7 +13,7 @@ class AuditEntry
      */
     protected $type;
     /**
-     * @var int
+     * @var int|string
      */
     protected $object_id;
     /**
@@ -65,9 +65,9 @@ class AuditEntry
     /**
      * Get the value of object_id.
      *
-     * @return int
+     * @return int|string
      */
-    public function getObjectId(): ?int
+    public function getObjectId()
     {
         return $this->object_id;
     }

--- a/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
@@ -64,6 +64,7 @@ class CreateSchemaListener implements EventSubscriber
             'notnull' => true,
             'length' => 10,
         ]);
+        // TODO: automate the object_id as integer or string based on original entity
         $auditTable->addColumn('object_id', 'integer', [
             'notnull' => true,
             'unsigned' => true,


### PR DESCRIPTION
This is a WIP, see TODO in `CreateSchemaListener.php`

The reason is simple.  I have a couple of entities (Language, Country) that use a 2-3 character code for the PK.  This allows that with a manual change to the migration file, from column type of INT to VARCHAR() or TEXT

With the manual change, and "audits" recorded, this is working, and I have not seen any side effects.