### PR TITLE
Non numeric primary key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,13 +354,19 @@ Contributing
 
 DoctrineAuditBundle is an open source project. Contributions made by the community are welcome. Send us your ideas, code reviews, pull requests and feature requests to help us improve this project.
 
-Do not forget to provide unit tests when contributing to this project.
+Do not forget to provide unit tests when contributing to this project. To do so, follow instructions in [this dedicated README](tests/README.md)
 
 
-Tests
-=====
+Supported DB
+============
 
-Please, follow instructions in [this dedicated README](tests/README.md)
+* MySQL
+* MariaDB
+* PostgreSQL
+* SQLite
+
+*This bundle should work with **any other** database supported by Doctrine. 
+Though, we can only really support the ones we can test with Travis-CI.*
 
 
 License

--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -23,8 +23,15 @@ class AuditController extends AbstractController
 
     /**
      * @Route("/audit/{entity}/{id}", name="dh_doctrine_audit_show_entity_history", methods={"GET"})
+     *
+     * @param string $entity
+     * @param string|int $id
+     * @param int $page
+     * @param int $pageSize
+     *
+     * @return Response
      */
-    public function showEntityHistoryAction(string $entity, int $id = null, int $page = 1, int $pageSize = 50): Response
+    public function showEntityHistoryAction(string $entity, $id = null, int $page = 1, int $pageSize = 50): Response
     {
         $reader = $this->container->get('dh_doctrine_audit.reader');
         $entries = $reader->getAudits($entity, $id, $page, $pageSize);
@@ -37,8 +44,13 @@ class AuditController extends AbstractController
 
     /**
      * @Route("/audit/details/{entity}/{id}", name="dh_doctrine_audit_show_audit_entry", methods={"GET"})
+     *
+     * @param string $entity
+     * @param string|int $id
+     *
+     * @return Response
      */
-    public function showAuditEntryAction(string $entity, int $id): Response
+    public function showAuditEntryAction(string $entity, $id): Response
     {
         $reader = $this->container->get('dh_doctrine_audit.reader');
         $data = $reader->getAudit($entity, $id);

--- a/src/DoctrineAuditBundle/Controller/AuditController.php
+++ b/src/DoctrineAuditBundle/Controller/AuditController.php
@@ -24,10 +24,10 @@ class AuditController extends AbstractController
     /**
      * @Route("/audit/{entity}/{id}", name="dh_doctrine_audit_show_entity_history", methods={"GET"})
      *
-     * @param string $entity
-     * @param string|int $id
-     * @param int $page
-     * @param int $pageSize
+     * @param string     $entity
+     * @param int|string $id
+     * @param int        $page
+     * @param int        $pageSize
      *
      * @return Response
      */
@@ -45,8 +45,8 @@ class AuditController extends AbstractController
     /**
      * @Route("/audit/details/{entity}/{id}", name="dh_doctrine_audit_show_audit_entry", methods={"GET"})
      *
-     * @param string $entity
-     * @param string|int $id
+     * @param string     $entity
+     * @param int|string $id
      *
      * @return Response
      */

--- a/src/DoctrineAuditBundle/Helper/AuditHelper.php
+++ b/src/DoctrineAuditBundle/Helper/AuditHelper.php
@@ -247,10 +247,9 @@ class AuditHelper
                 ],
             ],
             'object_id' => [
-                'type' => Type::INTEGER,
+                'type' => Type::STRING,
                 'options' => [
                     'notnull' => true,
-                    'unsigned' => true,
                 ],
             ],
             'diffs' => [

--- a/src/DoctrineAuditBundle/Reader/AuditEntry.php
+++ b/src/DoctrineAuditBundle/Reader/AuditEntry.php
@@ -8,30 +8,37 @@ class AuditEntry
      * @var int
      */
     protected $id;
+
     /**
      * @var string
      */
     protected $type;
+
     /**
-     * @var int
+     * @var string
      */
     protected $object_id;
+
     /**
      * @var string
      */
     protected $diffs;
+
     /**
      * @var int
      */
     protected $blame_id;
+
     /**
      * @var string
      */
     protected $blame_user;
+
     /**
      * @var string
      */
     protected $ip;
+
     /**
      * @var string
      */
@@ -65,9 +72,9 @@ class AuditEntry
     /**
      * Get the value of object_id.
      *
-     * @return int
+     * @return string
      */
-    public function getObjectId(): ?int
+    public function getObjectId(): string
     {
         return $this->object_id;
     }

--- a/src/DoctrineAuditBundle/Reader/AuditReader.php
+++ b/src/DoctrineAuditBundle/Reader/AuditReader.php
@@ -106,7 +106,7 @@ class AuditReader
      * Returns an array of audited entries/operations.
      *
      * @param object|string $entity
-     * @param string|int    $id
+     * @param int|string    $id
      * @param int           $page
      * @param int           $pageSize
      *
@@ -162,7 +162,7 @@ class AuditReader
 
     /**
      * @param object|string $entity
-     * @param string|int    $id
+     * @param int|string    $id
      *
      * @return mixed
      */

--- a/src/DoctrineAuditBundle/Reader/AuditReader.php
+++ b/src/DoctrineAuditBundle/Reader/AuditReader.php
@@ -106,13 +106,13 @@ class AuditReader
      * Returns an array of audited entries/operations.
      *
      * @param object|string $entity
-     * @param null|int      $id
+     * @param string|int    $id
      * @param int           $page
      * @param int           $pageSize
      *
      * @return array
      */
-    public function getAudits($entity, int $id = null, int $page = 1, int $pageSize = 50): array
+    public function getAudits($entity, $id = null, int $page = 1, int $pageSize = 50): array
     {
         if ($page < 1) {
             throw new \InvalidArgumentException('$page must be greater or equal than 1.');
@@ -162,11 +162,11 @@ class AuditReader
 
     /**
      * @param object|string $entity
-     * @param int           $id
+     * @param string|int    $id
      *
      * @return mixed
      */
-    public function getAudit($entity, int $id)
+    public function getAudit($entity, $id)
     {
         $connection = $this->entityManager->getConnection();
 

--- a/tests/DoctrineAuditBundle/Fixtures/Issues/Locale.php
+++ b/tests/DoctrineAuditBundle/Fixtures/Issues/Locale.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Tests\Fixtures\Issues;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="locale")
+ */
+class Locale
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", length=5)
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    protected $name;
+
+    /**
+     * Get the value of id.
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the value of id.
+     *
+     * @param string $id
+     *
+     * @return Locale
+     */
+    public function setId(string $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the value of name.
+     *
+     * @param string $name
+     *
+     * @return Locale
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function __sleep()
+    {
+        return ['id', 'name'];
+    }
+}

--- a/tests/DoctrineAuditBundle/Fixtures/Issues/User.php
+++ b/tests/DoctrineAuditBundle/Fixtures/Issues/User.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Tests\Fixtures\Issues;
+
+use DH\DoctrineAuditBundle\Tests\Fixtures\Issues\Locale;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="user")
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    protected $username;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $locale_id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Locale", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(name="locale_id", referencedColumnName="id", nullable=true)
+     */
+    protected $locale;
+
+    /**
+     * Get the value of id.
+     *
+     * @return mixed
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the value of id.
+     *
+     * @param int $id
+     *
+     * @return User
+     */
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of username.
+     *
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * Set the value of username.
+     *
+     * @param string $username
+     *
+     * @return User
+     */
+    public function setUsername(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of locale_id.
+     *
+     * @param string $locale_id
+     *
+     * @return User
+     */
+    public function setLocaleId(string $locale_id): self
+    {
+        $this->locale_id = $locale_id;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of locale_id.
+     *
+     * @return string
+     */
+    public function getLocaleId(): ?string
+    {
+        return $this->locale_id;
+    }
+
+    /**
+     * Set Locale entity (many to one).
+     *
+     * @param ?Locale $locale
+     *
+     * @return User
+     */
+    public function setLocale(?Locale $locale): self
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get Locale entity (many to one).
+     *
+     * @return ?Locale
+     */
+    public function getLocale(): ?Locale
+    {
+        return $this->locale;
+    }
+}

--- a/tests/DoctrineAuditBundle/Fixtures/Issues/User.php
+++ b/tests/DoctrineAuditBundle/Fixtures/Issues/User.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="user")
+ * @ORM\Table(name="users")
  */
 class User
 {

--- a/tests/DoctrineAuditBundle/IssueTest.php
+++ b/tests/DoctrineAuditBundle/IssueTest.php
@@ -5,6 +5,8 @@ namespace DH\DoctrineAuditBundle\Tests;
 use DH\DoctrineAuditBundle\Reader\AuditReader;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Issues\CoreCase;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Issues\DieselCase;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Issues\Locale;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Issues\User;
 
 /**
  * @covers \DH\DoctrineAuditBundle\AuditConfiguration
@@ -26,6 +28,78 @@ class IssueTest extends BaseTest
      */
     protected $fixturesPath = __DIR__.'/Fixtures/Issues';
 
+    public function testIssue40(): void
+    {
+        $em = $this->getEntityManager();
+        $reader = $this->getReader($this->getAuditConfiguration());
+
+        $coreCase = new CoreCase();
+        $coreCase->type = 'type1';
+        $coreCase->status = 'status1';
+        $em->persist($coreCase);
+        $em->flush();
+
+        $dieselCase = new DieselCase();
+        $dieselCase->coreCase = $coreCase;
+        $dieselCase->setName('yo');
+        $em->persist($dieselCase);
+        $em->flush();
+
+        $audits = $reader->getAudits(CoreCase::class);
+        $this->assertCount(1, $audits, 'results count ok.');
+        $this->assertSame(AuditReader::INSERT, $audits[0]->getType(), 'AuditReader::INSERT operation.');
+
+        $audits = $reader->getAudits(DieselCase::class);
+        $this->assertCount(1, $audits, 'results count ok.');
+        $this->assertSame(AuditReader::INSERT, $audits[0]->getType(), 'AuditReader::INSERT operation.');
+    }
+
+    public function testIssue37(): void
+    {
+        $em = $this->getEntityManager();
+        $reader = $this->getReader($this->getAuditConfiguration());
+
+        $localeFR = new Locale();
+        $localeFR
+            ->setId('fr_FR')
+            ->setName('Français')
+        ;
+        $em->persist($localeFR);
+        $em->flush();
+
+        $localeEN = new Locale();
+        $localeEN
+            ->setId('en_US')
+            ->setName('Français')
+        ;
+        $em->persist($localeEN);
+        $em->flush();
+
+        $audits = $reader->getAudits(Locale::class);
+        $this->assertCount(2, $audits, 'results count ok.');
+        $this->assertSame('en_US', $audits[0]->getObjectId(), 'AuditEntry::object_id is a string.');
+        $this->assertSame('fr_FR', $audits[1]->getObjectId(), 'AuditEntry::object_id is a string.');
+
+        $user1 = new User();
+        $user1
+            ->setUsername('john.doe')
+            ->setLocale($localeFR)
+        ;
+        $em->persist($user1);
+        $em->flush();
+
+        $user2 = new User();
+        $user2
+            ->setUsername('dark.vador')
+            ->setLocale($localeEN)
+        ;
+        $em->persist($user2);
+        $em->flush();
+
+        $audits = $reader->getAudits(User::class);
+        $this->assertCount(2, $audits, 'results count ok.');
+    }
+
     /**
      * @throws \Doctrine\DBAL\DBALException
      * @throws \Doctrine\ORM\ORMException
@@ -40,39 +114,10 @@ class IssueTest extends BaseTest
         $configuration->setEntities([
             DieselCase::class => ['enabled' => true],
             CoreCase::class => ['enabled' => true],
+            Locale::class => ['enabled' => true],
+            User::class => ['enabled' => true],
         ]);
 
         $this->setUpEntitySchema();
-        $this->setupEntities();
-    }
-
-    public function testIssue40(): void
-    {
-        $reader = $this->getReader($this->getAuditConfiguration());
-
-        $audits = $reader->getAudits(CoreCase::class);
-        $this->assertCount(1, $audits, 'results count ok.');
-        $this->assertSame(AuditReader::INSERT, $audits[0]->getType(), 'AuditReader::INSERT operation.');
-
-        $audits = $reader->getAudits(DieselCase::class);
-        $this->assertCount(1, $audits, 'results count ok.');
-        $this->assertSame(AuditReader::INSERT, $audits[0]->getType(), 'AuditReader::INSERT operation.');
-    }
-
-    protected function setupEntities(): void
-    {
-        $em = $this->getEntityManager();
-
-        $coreCase = new CoreCase();
-        $coreCase->type = 'type1';
-        $coreCase->status = 'status1';
-        $em->persist($coreCase);
-        $em->flush();
-
-        $dieselCase = new DieselCase();
-        $dieselCase->coreCase = $coreCase;
-        $dieselCase->setName('yo');
-        $em->persist($dieselCase);
-        $em->flush();
     }
 }

--- a/tests/DoctrineAuditBundle/Reader/AuditEntryTest.php
+++ b/tests/DoctrineAuditBundle/Reader/AuditEntryTest.php
@@ -15,7 +15,7 @@ class AuditEntryTest extends TestCase
         $entry = new AuditEntry();
         $entry->id = 1;
         $entry->type = 'type';
-        $entry->object_id = 1;
+        $entry->object_id = '1';
         $entry->diffs = '{}';
         $entry->blame_id = 1;
         $entry->blame_user = 'John Doe';
@@ -24,7 +24,7 @@ class AuditEntryTest extends TestCase
 
         $this->assertSame(1, $entry->getId(), 'AuditEntry::getId() is ok.');
         $this->assertSame('type', $entry->getType(), 'AuditEntry::getType() is ok.');
-        $this->assertSame(1, $entry->getObjectId(), 'AuditEntry::getObjectId() is ok.');
+        $this->assertSame('1', $entry->getObjectId(), 'AuditEntry::getObjectId() is ok.');
         $this->assertSame([], $entry->getDiffs(), 'AuditEntry::getDiffs() is ok.');
         $this->assertSame(1, $entry->getUserId(), 'AuditEntry::getUserId() is ok.');
         $this->assertSame('John Doe', $entry->getUsername(), 'AuditEntry::getUsername() is ok.');


### PR DESCRIPTION
As of now, `AuditEntry::object_id` is a string. This allows to support auditing entities with non numeric primary key.