### PR TITLE
Nested LoggerChains causing big call stack 

### DIFF
--- a/src/DoctrineAuditBundle/DBAL/AuditLoggerChain.php
+++ b/src/DoctrineAuditBundle/DBAL/AuditLoggerChain.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: acanicatti@smart-trade.net
+ * Date: 8/14/19
+ * Time: 3:50 PM
+ */
+
+namespace DH\DoctrineAuditBundle\DBAL;
+
+
+use Doctrine\DBAL\Logging\SQLLogger;
+
+class AuditLoggerChain implements SQLLogger
+{
+    /** @var SQLLogger[] */
+    private $loggers = [];
+
+    /**
+     * Adds a logger in the chain.
+     *
+     * @param SQLLogger $logger
+     * @return void
+     */
+    public function addLogger(SQLLogger $logger)
+    {
+        $this->loggers[] = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startQuery($sql, ?array $params = null, ?array $types = null)
+    {
+        foreach ($this->loggers as $logger) {
+            $logger->startQuery($sql, $params, $types);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stopQuery()
+    {
+        foreach ($this->loggers as $logger) {
+            $logger->stopQuery();
+        }
+    }
+
+    /**
+     * @return SQLLogger[]
+     */
+    public function getLoggers()
+    {
+        return $this->loggers;
+    }
+}

--- a/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/AuditSubscriber.php
@@ -62,18 +62,18 @@ class AuditSubscriber implements EventSubscriber
             $this->manager->reset();
         });
 
-        // Embed the chain into the existing LoggerChain, or create a new chain embed the existing SQLLogger.
-        $newChain = new AuditLoggerChain();
-        $newChain->addLogger($auditLogger);
+        // Initialize a new LoggerChain with the new AuditLogger + the existing SQLLoggers.
+        $loggerChain = new AuditLoggerChain();
+        $loggerChain->addLogger($auditLogger);
         if ($this->loggerBackup instanceof AuditLoggerChain) {
             /** @var SQLLogger $logger */
             foreach ($this->loggerBackup->getLoggers() as $logger) {
-                $newChain->addLogger($logger);
+                $loggerChain->addLogger($logger);
             }
         } elseif ($this->loggerBackup instanceof SQLLogger) {
-            $newChain->addLogger($this->loggerBackup);
+            $loggerChain->addLogger($this->loggerBackup);
         }
-        $em->getConnection()->getConfiguration()->setSQLLogger($newChain);
+        $em->getConnection()->getConfiguration()->setSQLLogger($loggerChain);
 
         $this->manager->collectScheduledInsertions($uow);
         $this->manager->collectScheduledUpdates($uow);

--- a/src/DoctrineAuditBundle/Helper/AuditHelper.php
+++ b/src/DoctrineAuditBundle/Helper/AuditHelper.php
@@ -215,7 +215,10 @@ class AuditHelper
         $meta = $em->getClassMetadata(\get_class($entity));
         $pkName = $meta->getSingleIdentifierFieldName();
         $pkValue = $id ?? $this->id($em, $entity);
-        if (is_null($pkValue)) return null; // An added guard for proxies that fail to initialize.
+        // An added guard for proxies that fail to initialize.
+        if (is_null($pkValue)) {
+            return null;
+        }
 
         if (method_exists($entity, '__toString')) {
             $label = (string) $entity;

--- a/src/DoctrineAuditBundle/Helper/AuditHelper.php
+++ b/src/DoctrineAuditBundle/Helper/AuditHelper.php
@@ -215,6 +215,7 @@ class AuditHelper
         $meta = $em->getClassMetadata(\get_class($entity));
         $pkName = $meta->getSingleIdentifierFieldName();
         $pkValue = $id ?? $this->id($em, $entity);
+        if (is_null($pkValue)) return null; // An added guard for proxies that fail to initialize.
 
         if (method_exists($entity, '__toString')) {
             $label = (string) $entity;

--- a/src/DoctrineAuditBundle/Helper/AuditHelper.php
+++ b/src/DoctrineAuditBundle/Helper/AuditHelper.php
@@ -216,7 +216,7 @@ class AuditHelper
         $pkName = $meta->getSingleIdentifierFieldName();
         $pkValue = $id ?? $this->id($em, $entity);
         // An added guard for proxies that fail to initialize.
-        if (is_null($pkValue)) {
+        if (null == $pkValue) {
             return null;
         }
 


### PR DESCRIPTION
See Issue 70. LoggerChains are nested inside each other and when Doctrine calls startQuery on the EntityManager's SQLLogger, the LoggerChains will create call stacks for each nest. If xdebug is enabled, once the call stack reaches the "max_nesting_level", an Exception will be thrown. 

This code flattens the EntityManager's SQLLogger by detecting if it is already a LoggerChain and if so only appending the AuditLogger created. 