### PR TITLE
Allow timezone to be configured in package configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ dh_doctrine_audit:
     table_suffix: '_audit'
 ```
 
+### Timezone
+
+You can configure the timezone the audit `created_at` is generated in. This by default is 'UTC'.
+
+```yaml
+// app/config/config.yml (symfony < 3.4)
+// config/packages/dh_doctrine_audit.yaml (symfony >= 3.4)
+dh_doctrine_audit:
+    timezone: 'Europe/London'
+```
+
 ### Creating audit tables
 
 Open a command console, enter your project directory and execute the

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -20,6 +20,11 @@ class AuditConfiguration
     private $tableSuffix;
 
     /**
+     * @var string
+     */
+    private $timezone;
+
+    /**
      * @var array
      */
     private $ignoredColumns = [];
@@ -57,6 +62,7 @@ class AuditConfiguration
 
         $this->tablePrefix = $config['table_prefix'];
         $this->tableSuffix = $config['table_suffix'];
+        $this->timezone = $config['timezone'];
         $this->ignoredColumns = $config['ignored_columns'];
 
         if (isset($config['entities']) && !empty($config['entities'])) {
@@ -224,6 +230,16 @@ class AuditConfiguration
     public function getTableSuffix(): string
     {
         return $this->tableSuffix;
+    }
+
+    /**
+     * Get the value of timezone
+     *
+     * @return string
+     */
+    public function getTimezone(): string
+    {
+        return $this->timezone;
     }
 
     /**

--- a/src/DoctrineAuditBundle/AuditManager.php
+++ b/src/DoctrineAuditBundle/AuditManager.php
@@ -226,7 +226,7 @@ class AuditManager
 
         $statement = $em->getConnection()->prepare($query);
 
-        $dt = new \DateTime('now', new \DateTimeZone('UTC'));
+        $dt = new \DateTime('now', new \DateTimeZone($this->getConfiguration()->getTimezone()));
         $statement->bindValue('type', $data['action']);
         $statement->bindValue('object_id', (string) $data['id']);
         $statement->bindValue('diffs', json_encode($data['diff']));

--- a/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
@@ -33,6 +33,10 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
 
+                ->scalarNode('timezone')
+                    ->defaultValue('UTC')
+                ->end()
+
                 ->arrayNode('entities')
                     ->canBeUnset()
                     ->prototype('array')

--- a/tests/DoctrineAuditBundle/AuditConfigurationTest.php
+++ b/tests/DoctrineAuditBundle/AuditConfigurationTest.php
@@ -363,6 +363,22 @@ class AuditConfigurationTest extends TestCase
         $this->assertFalse($configuration->isAudited(Post::class), 'entity "'.Post::class.'" is not audited.');
     }
 
+    public function testDefaultTimezone(): void
+    {
+        $configuration = $this->getAuditConfiguration();
+
+        $this->assertSame('UTC', $configuration->getTimezone(), 'timezone is UTC by default.');
+    }
+
+    public function testCustomTimezone(): void
+    {
+        $configuration = $this->getAuditConfiguration([
+            'timezone' => 'Europe/London',
+        ]);
+
+        $this->assertSame('Europe/London', $configuration->getTimezone(), 'custom timezone is "Europe/London".');
+    }
+
     protected function getAuditConfiguration(array $options = []): AuditConfiguration
     {
         $container = new ContainerBuilder();
@@ -371,6 +387,7 @@ class AuditConfigurationTest extends TestCase
             array_merge([
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [],
                 'enabled' => true,

--- a/tests/DoctrineAuditBundle/BaseTest.php
+++ b/tests/DoctrineAuditBundle/BaseTest.php
@@ -125,6 +125,7 @@ abstract class BaseTest extends TestCase
             array_merge([
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [],
             ], $options),

--- a/tests/DoctrineAuditBundle/CoreTest.php
+++ b/tests/DoctrineAuditBundle/CoreTest.php
@@ -254,6 +254,7 @@ abstract class CoreTest extends BaseTest
             array_merge([
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [],
             ], $options),

--- a/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
@@ -69,6 +69,7 @@ class DHDoctrineAuditExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('dh_doctrine_audit.configuration', [
             'table_prefix' => '',
             'table_suffix' => '_audit',
+            'timezone' => 'UTC',
             'ignored_columns' => [],
             'entities' => [],
         ]);

--- a/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
@@ -199,6 +199,7 @@ class AuditHelperTest extends CoreTest
             [
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [
                     'created_at',
                     'updated_at',
@@ -258,6 +259,7 @@ class AuditHelperTest extends CoreTest
             [
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [
                     Post::class => [
@@ -378,6 +380,7 @@ class AuditHelperTest extends CoreTest
             [
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [],
             ],
@@ -404,6 +407,7 @@ class AuditHelperTest extends CoreTest
             [
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
+                'timezone' => 'UTC',
                 'ignored_columns' => [],
                 'entities' => [],
             ],


### PR DESCRIPTION
In certain scenarios, it is useful for the audit `created_at` timestamp to be in the same timezone as the users using the application. In our application this prevents confusion when viewing audits and simplifies the view logic.

This pull request allows the developer to configure a custom timezone in YAML which audits are saved based on. If the configuration isn't present it replicates the existing behaviour of defaulting to UTC.