### PR TITLE
Add global enabled configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ dh_doctrine_audit:
     timezone: 'Europe/London'
 ```
 
+### Global Enable
+
+You can globally enable or disable the auditing of entities. By default, it will audit entities.
+
+```yaml
+// app/config/config.yml (symfony < 3.4)
+// config/packages/dh_doctrine_audit.yaml (symfony >= 3.4)
+dh_doctrine_audit:
+    global_enabled: '%env(bool:AUDITING_ENABLED)%'
+```
+
 ### Creating audit tables
 
 Open a command console, enter your project directory and execute the

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -25,6 +25,11 @@ class AuditConfiguration
     private $timezone;
 
     /**
+     * @var bool
+     */
+    private $globalEnabled;
+
+    /**
      * @var array
      */
     private $ignoredColumns = [];
@@ -63,6 +68,7 @@ class AuditConfiguration
         $this->tablePrefix = $config['table_prefix'];
         $this->tableSuffix = $config['table_suffix'];
         $this->timezone = $config['timezone'];
+        $this->globalEnabled = $config['global_enabled'];
         $this->ignoredColumns = $config['ignored_columns'];
 
         if (isset($config['entities']) && !empty($config['entities'])) {
@@ -240,6 +246,16 @@ class AuditConfiguration
     public function getTimezone(): string
     {
         return $this->timezone;
+    }
+
+    /**
+     * Get the value of globalEnabled
+     *
+     * @return bool
+     */
+    public function isGlobalEnabled(): bool
+    {
+        return $this->globalEnabled;
     }
 
     /**

--- a/src/DoctrineAuditBundle/AuditManager.php
+++ b/src/DoctrineAuditBundle/AuditManager.php
@@ -203,6 +203,10 @@ class AuditManager
      */
     private function audit(EntityManager $em, array $data): void
     {
+        if (!$this->getConfiguration()->isGlobalEnabled()) {
+            return;
+        }
+
         $schema = $data['schema'] ? $data['schema'].'.' : '';
         $auditTable = $schema.$this->configuration->getTablePrefix().$data['table'].$this->configuration->getTableSuffix();
         $fields = [

--- a/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
@@ -37,6 +37,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('UTC')
                 ->end()
 
+                ->scalarNode('global_enabled')
+                    ->defaultTrue()
+                ->end()
+
                 ->arrayNode('entities')
                     ->canBeUnset()
                     ->prototype('array')

--- a/tests/DoctrineAuditBundle/AuditConfigurationTest.php
+++ b/tests/DoctrineAuditBundle/AuditConfigurationTest.php
@@ -379,6 +379,13 @@ class AuditConfigurationTest extends TestCase
         $this->assertSame('Europe/London', $configuration->getTimezone(), 'custom timezone is "Europe/London".');
     }
 
+    public function testDefaultGlobalEnabled(): void
+    {
+        $configuration = $this->getAuditConfiguration();
+
+        $this->assertTrue($configuration->isGlobalEnabled(), 'global_enabled is true by default');
+    }
+
     protected function getAuditConfiguration(array $options = []): AuditConfiguration
     {
         $container = new ContainerBuilder();
@@ -388,6 +395,7 @@ class AuditConfigurationTest extends TestCase
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [],
                 'enabled' => true,

--- a/tests/DoctrineAuditBundle/AuditManagerTest.php
+++ b/tests/DoctrineAuditBundle/AuditManagerTest.php
@@ -560,6 +560,33 @@ class AuditManagerTest extends CoreTest
         $this->assertInstanceOf(AuditHelper::class, $manager->getHelper(), 'helper instanceof AuditHelper::class');
     }
 
+    public function testAuditNotInsertedWhenGloballyDisabled(): void
+    {
+        $em = $this->getEntityManager();
+        $configuration = $this->createAuditConfiguration([
+            'global_enabled' => false,
+        ]);
+        $helper = new AuditHelper($configuration);
+        $manager = new AuditManager($configuration, $helper);
+        $reader = new AuditReader($configuration, $em);
+
+        $author = new Author();
+        $author
+            ->setId(1)
+            ->setFullname('John Doe')
+            ->setEmail('john.doe@gmail.com')
+        ;
+
+        $manager->insert($em, $author, [
+            'fullname' => [null, 'John Doe'],
+            'email' => [null, 'john.doe@gmail.com'],
+        ]);
+
+        $audits = $reader->getAudits(Author::class);
+
+        $this->assertEmpty($audits, 'no audits created on global enable disabled');
+    }
+
     protected function setupEntities(): void
     {
     }

--- a/tests/DoctrineAuditBundle/BaseTest.php
+++ b/tests/DoctrineAuditBundle/BaseTest.php
@@ -126,6 +126,7 @@ abstract class BaseTest extends TestCase
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [],
             ], $options),

--- a/tests/DoctrineAuditBundle/CoreTest.php
+++ b/tests/DoctrineAuditBundle/CoreTest.php
@@ -255,6 +255,7 @@ abstract class CoreTest extends BaseTest
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [],
             ], $options),

--- a/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
@@ -70,6 +70,7 @@ class DHDoctrineAuditExtensionTest extends AbstractExtensionTestCase
             'table_prefix' => '',
             'table_suffix' => '_audit',
             'timezone' => 'UTC',
+            'global_enabled' => true,
             'ignored_columns' => [],
             'entities' => [],
         ]);

--- a/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
@@ -200,6 +200,7 @@ class AuditHelperTest extends CoreTest
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [
                     'created_at',
                     'updated_at',
@@ -260,6 +261,7 @@ class AuditHelperTest extends CoreTest
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [
                     Post::class => [
@@ -381,6 +383,7 @@ class AuditHelperTest extends CoreTest
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [],
             ],
@@ -408,6 +411,7 @@ class AuditHelperTest extends CoreTest
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
+                'global_enabled' => true,
                 'ignored_columns' => [],
                 'entities' => [],
             ],


### PR DESCRIPTION
Sometimes you would like to disable auditing globally rather than specifying it per entity. As an example, when developing locally you wouldn't necessarily need auditing enabled but in production you would. 

This pull request reduces the need for doing this per entity:

```yaml
dh_doctrine_audit:
    entities:
        App\Entity\Example1:
            enabled: '%env(bool:AUDITING_ENABLED)%'
        App\Entity\Example2:
            enabled: '%env(bool:AUDITING_ENABLED)%'
        App\Entity\Example3:
            enabled: '%env(bool:AUDITING_ENABLED)%'
```

and allows you to simplify this, keeping your configuration clean, like so:

```yaml
dh_doctrine_audit:
    global_enabled: '%env(bool:AUDITING_ENABLED)%' 
```

The default value `global_enabled` is to audit as.