### PR TITLE
Single table inheritance support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Performance enhancements when saving a lot of entities at once (closes #70, thanks to @acanicatti).
 * Remove deprecated and manage the compatibility (thanks to @maxhelias).
 * Fixed an issue with `audit:schema:update` command when run against a database with no audit table (#85)
+* SINGLE_TABLE inheritance support
 
 ### Breaking changes
 * The structure of audit tables has changed so you have to run the migration command right after updating
@@ -29,7 +30,7 @@ or run
 composer require damienharper/doctrine-audit-bundle ^3.0
 ```
 
-Due to internal changes requiring a new column and `blame_id` column type change, run the migration command after updating the bundle to update the structure of your current audit tables.
+Due to internal changes requiring new columns and `blame_id` column type change, run the migration command after updating the bundle to update the structure of your current audit tables.
 ```bash
 bin/console audit:schema:update
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# DoctrineAuditBundle [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Create%20audit%20logs%20for%20all%20Doctrine%20ORM%20database%20related%20changes%20with%20DoctrineAuditBundle.&url=https://github.com/DamienHarper/DoctrineAuditBundle&hashtags=doctrine-audit-log-bundle)
+DoctrineAuditBundle [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Create%20audit%20logs%20for%20all%20Doctrine%20ORM%20database%20related%20changes%20with%20DoctrineAuditBundle.&url=https://github.com/DamienHarper/DoctrineAuditBundle&hashtags=doctrine-audit-log-bundle)
+===================
 
 [![Latest Stable Version](https://poser.pugx.org/damienharper/doctrine-audit-bundle/v/stable)](https://packagist.org/packages/damienharper/doctrine-audit-bundle)
 [![Latest Unstable Version](https://poser.pugx.org/damienharper/doctrine-audit-bundle/v/unstable)](https://packagist.org/packages/damienharper/doctrine-audit-bundle)
@@ -155,6 +156,12 @@ You can configure the timezone the audit `created_at` is generated in. This by d
 dh_doctrine_audit:
     timezone: 'Europe/London'
 ```
+
+### Single Table Inheritance
+
+This bundle supports Doctrine SINGLE_TABLE inheritance.
+Configuring the root table to be audited does not suffice to get all child tables audited.
+You have to configure every child table that needs to be audited as well.
 
 ### Creating audit tables
 
@@ -429,6 +436,18 @@ FAQ:
 #### I don't use Symfony's `TokenStorage` to manage my users, how do I proceed?
 
 > Check the [Custom user provider](#custom-user-provider) section.
+
+#### I want to store audit data in a dedicated database, how to do it?
+
+> Check the [Custom database for storage audit](#custom-database-for-storage-audit) section.
+
+#### I use Doctrine SINGLE_TABLE inheritance and I've configured an entity to be audited but its child are not audited, how to proceed?
+
+> Check the [Single Table Inheritance](#single-table-inheritance) section.
+
+#### I want to disable or enable auditing dynamically, is this possible?
+
+> Check the [Enabling and disabling the auditing of entities](#enabling-and-disabling-the-auditing-of-entities) section.
 
 
 Contributing

--- a/src/DoctrineAuditBundle/AuditManager.php
+++ b/src/DoctrineAuditBundle/AuditManager.php
@@ -195,7 +195,7 @@ class AuditManager
             'schema' => $meta->getSchemaName(),
             'id' => $this->helper->id($em, $source),
             'transaction_hash' => $this->getTransactionHash(),
-            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($entity) : null,
+            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($source) : null,
         ];
 
         if (isset($mapping['joinTable']['name'])) {

--- a/src/DoctrineAuditBundle/AuditManager.php
+++ b/src/DoctrineAuditBundle/AuditManager.php
@@ -5,6 +5,7 @@ namespace DH\DoctrineAuditBundle;
 use DH\DoctrineAuditBundle\Helper\AuditHelper;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 class AuditManager
 {
@@ -78,6 +79,7 @@ class AuditManager
             'schema' => $meta->getSchemaName(),
             'id' => $this->helper->id($em, $entity),
             'transaction_hash' => $this->getTransactionHash(),
+            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($entity) : null,
         ]);
     }
 
@@ -106,6 +108,7 @@ class AuditManager
             'schema' => $meta->getSchemaName(),
             'id' => $this->helper->id($em, $entity),
             'transaction_hash' => $this->getTransactionHash(),
+            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($entity) : null,
         ]);
     }
 
@@ -130,6 +133,7 @@ class AuditManager
             'schema' => $meta->getSchemaName(),
             'id' => $id,
             'transaction_hash' => $this->getTransactionHash(),
+            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($entity) : null,
         ]);
     }
 
@@ -191,6 +195,7 @@ class AuditManager
             'schema' => $meta->getSchemaName(),
             'id' => $this->helper->id($em, $source),
             'transaction_hash' => $this->getTransactionHash(),
+            'discriminator' => $meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE ? \get_class($entity) : null,
         ];
 
         if (isset($mapping['joinTable']['name'])) {
@@ -215,6 +220,7 @@ class AuditManager
         $fields = [
             'type' => ':type',
             'object_id' => ':object_id',
+            'discriminator' => ':discriminator',
             'transaction_hash' => ':transaction_hash',
             'diffs' => ':diffs',
             'blame_id' => ':blame_id',
@@ -238,6 +244,7 @@ class AuditManager
         $dt = new \DateTime('now', new \DateTimeZone($this->getConfiguration()->getTimezone()));
         $statement->bindValue('type', $data['action']);
         $statement->bindValue('object_id', (string) $data['id']);
+        $statement->bindValue('discriminator', $data['discriminator']);
         $statement->bindValue('transaction_hash', (string) $data['transaction_hash']);
         $statement->bindValue('diffs', json_encode($data['diff']));
         $statement->bindValue('blame_id', $data['blame']['user_id']);

--- a/src/DoctrineAuditBundle/Helper/AuditHelper.php
+++ b/src/DoctrineAuditBundle/Helper/AuditHelper.php
@@ -266,6 +266,13 @@ class AuditHelper
                     'notnull' => true,
                 ],
             ],
+            'discriminator' => [
+                'type' => Type::STRING,
+                'options' => [
+                    'default' => null,
+                    'notnull' => false,
+                ],
+            ],
             'transaction_hash' => [
                 'type' => Type::STRING,
                 'options' => [
@@ -341,6 +348,10 @@ class AuditHelper
             'object_id' => [
                 'type' => 'index',
                 'name' => 'object_id_'.md5($tablename).'_idx',
+            ],
+            'discriminator' => [
+                'type' => 'index',
+                'name' => 'discriminator_'.md5($tablename).'_idx',
             ],
             'transaction_hash' => [
                 'type' => 'index',

--- a/tests/DoctrineAuditBundle/Fixtures/Core/Vehicle.php
+++ b/tests/DoctrineAuditBundle/Fixtures/Core/Vehicle.php
@@ -9,9 +9,9 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(name="vehicle")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="type", type="string")
- * @ORM\DiscriminatorMap({"car": "Car", "bike": "Bike"})
+ * @ORM\DiscriminatorMap({"vehicle": "Vehicle", "car": "Car", "bike": "Bike"})
  */
-abstract class Vehicle
+class Vehicle
 {
     /**
      * @ORM\Id

--- a/tests/DoctrineAuditBundle/IssueTest.php
+++ b/tests/DoctrineAuditBundle/IssueTest.php
@@ -51,7 +51,32 @@ final class IssueTest extends BaseTest
         $em->persist($bike);
         $em->flush();
 
+        $tryke = new Vehicle();
+        $tryke->setLabel('Can-am Spyder');
+        $tryke->setWheels(3);
+        $em->persist($tryke);
+        $em->flush();
+
         $audits = $reader->getAudits(Vehicle::class);
+        static::assertCount(1, $audits, 'results count ok.');
+
+        $audits = $reader->getAudits(Vehicle::class, null, null, null, null, false);
+        static::assertCount(3, $audits, 'results count ok.');
+
+        $audits = $reader->getAudits(Car::class);
+        static::assertCount(1, $audits, 'results count ok.');
+
+        $audits = $reader->getAudits(Bike::class);
+        static::assertCount(1, $audits, 'results count ok.');
+
+        $car->setLabel('Taycan');
+        $em->persist($car);
+        $em->flush();
+
+        $audits = $reader->getAudits(Vehicle::class);
+        static::assertCount(1, $audits, 'results count ok.');
+
+        $audits = $reader->getAudits(Car::class);
         static::assertCount(2, $audits, 'results count ok.');
     }
 
@@ -143,6 +168,7 @@ final class IssueTest extends BaseTest
             CoreCase::class => ['enabled' => true],
             Locale::class => ['enabled' => true],
             User::class => ['enabled' => true],
+            Vehicle::class => ['enabled' => true],
             Car::class => ['enabled' => true],
             Bike::class => ['enabled' => true],
         ]);


### PR DESCRIPTION
Although STI was supported, there was no way to get audits about a specific child entity, `AuditReader::getAudits()` was getting audits of both the root entity and of its children.
This PR addresses this limitation.