### PR TITLE
Bring back the schema listener and restrict its usage to single database setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.0.0] - Not yet released
 ### Changes
 * The bundle now supports non numeric IDs for the `User` objects (closes #66, thanks to @Gonzalo1987).
-* A transaction hash is now stored in audit tables and makes it easier to identify all operations performed in the same transaction (closes #69)
-  - The timeline now displays a transaction hash for each element. By clicking a transaction hash, you get a complete overview of all the operations included into the transaction.
-  - `AuditReader::getAudits()` now accepts a transaction hash as fifth parameter to return audits logged in the given transaction for the given entity.
-  - `AuditReader::getAuditsByTransactionHash()` accepts a transaction hash as parameter and returns all the audits logged in the given transaction.
+* A transaction hash is now stored in audit tables and makes it easier to identify all operations performed 
+in the same transaction (closes #69)
+  - The timeline now displays a transaction hash for each element. By clicking a transaction hash, 
+  you get a complete overview of all the operations included into the transaction.
+  - `AuditReader::getAudits()` now accepts a transaction hash as fifth parameter to return audits 
+  logged in the given transaction for the given entity.
+  - `AuditReader::getAuditsByTransactionHash()` accepts a transaction hash as parameter and returns 
+  all the audits logged in the given transaction.
 * Performance enhancements when saving a lot of entities at once (closes #70, thanks to @acanicatti).
 * Remove deprecated and manage the compatibility (thanks to @maxhelias).
 * Fixed an issue with `audit:schema:update` command when run against a database with no audit table (#85)
-* SINGLE_TABLE inheritance support (#73)
-  - `AuditReader::getAudits()` now accepts a boolean as sixth parameter to return either audits for the given entity only or audits for the given entity hierarchy.
+* `SINGLE_TABLE` inheritance support (#73)
+  - `AuditReader::getAudits()` now accepts a boolean as sixth parameter to return either audits 
+  for the given entity only or audits for the given entity hierarchy.
 
 ### Breaking changes
-* Doctrine's `doctrine:schema:update` command do not create audit tables automatically anymore (this command cannot work with multiple
-databases simultaneously), use the bundled migration command instead (supports the same options as Doctrine's command).
+* Doctrine's `doctrine:schema:update` command do not create audit tables automatically anymore 
+**when using a secondary database** (this command cannot work with multiple databases simultaneously), 
+use the bundled migration command instead which supports the same options as Doctrine's command.
   - `bin/console audit:schema:update --dump-sql` prints SQL queries that need be executed.
   - `bin/console audit:schema:update --force` executes relevant SQL queries.
 * The structure of audit tables has changed so you have to run the migration command right after updating
 * `AuditEntry::getUserId()` now return a `string` or `null` instead of an `int`.
 * The bundle requires `mbstring` extension (cf. https://www.php.net/manual/en/mbstring.installation.php)
-* Configuration has changed to use a secondary database: you now only need to inject the dedicated entity manager to `AuditConfiguration` service as described [here](https://github.com/DamienHarper/DoctrineAuditBundle#custom-database-for-storage-audit)
+* Configuration has changed to use a secondary database: you now only need to inject the dedicated 
+entity manager to `AuditConfiguration` service as described [here](https://github.com/DamienHarper/DoctrineAuditBundle#custom-database-for-storage-audit)
 
 ### How to upgrade?
 Either update your `composer.json` file manually to include `"damienharper/doctrine-audit-bundle": "^3.0"` 

--- a/README.md
+++ b/README.md
@@ -159,15 +159,65 @@ dh_doctrine_audit:
 
 ### Single Table Inheritance
 
-This bundle supports Doctrine SINGLE_TABLE inheritance.
+This bundle supports Doctrine `SINGLE_TABLE` inheritance.
 Configuring the root table to be audited does not suffice to get all child tables audited.
 You have to configure every child table that needs to be audited as well.
 
-### Creating (and updating) audit tables
+### Creating audit tables
+
+The process of audit table creation differs depending on your current setup:
+- **single** database setup: audit tables are stored in the **same** database than audited ones (most common use case)
+- **dual** database setup: audit tables are stored in a **secondary** database
+
+#### Single database setup (most common use case)
 
 Open a command console, enter your project directory and execute the
-following command to review the new audit tables (and/or audit table transformations after upgrading the bundle
-to a newer major version) in the update schema queue.
+following command to review the new audit tables in the update schema queue.
+
+```bash
+# symfony < 3.4
+app/console doctrine:schema:update --dump-sql 
+```
+
+```bash
+# symfony >= 3.4
+bin/console doctrine:schema:update --dump-sql 
+```
+
+##### Using [DoctrineMigrationsBundle](http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html)
+
+```bash
+# symfony < 3.4
+app/console doctrine:migrations:diff
+app/console doctrine:migrations:migrate
+```
+
+```bash
+# symfony >= 3.4
+bin/console doctrine:migrations:diff
+bin/console doctrine:migrations:migrate
+```
+
+##### Using Doctrine Schema
+    
+```bash
+# symfony < 3.4
+app/console doctrine:schema:update --force
+```
+
+```bash
+# symfony >= 3.4
+bin/console doctrine:schema:update --force
+```
+
+#### Dual database setup
+
+Doctrine `Schema-Tool` and `DoctrineMigrationsBundle` are not able to work with more than one
+database at once. To workaround that limitation, this bundle offers a migration command that 
+focuses on audit schema manipulation.
+
+Open a command console, enter your project directory and execute the following command to 
+review the new audit tables in the update schema queue.
 
 ```bash
 # symfony < 3.4

--- a/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
+++ b/src/DoctrineAuditBundle/EventSubscriber/CreateSchemaListener.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\EventSubscriber;
+
+use DH\DoctrineAuditBundle\Helper\UpdateHelper;
+use DH\DoctrineAuditBundle\Manager\AuditManager;
+use DH\DoctrineAuditBundle\Reader\AuditReader;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+
+class CreateSchemaListener implements EventSubscriber
+{
+    /**
+     * @var AuditManager
+     */
+    protected $manager;
+
+    /**
+     * @var AuditReader
+     */
+    protected $reader;
+
+    public function __construct(AuditManager $manager, AuditReader $reader)
+    {
+        $this->manager = $manager;
+        $this->reader = $reader;
+    }
+
+    public function postGenerateSchemaTable(GenerateSchemaTableEventArgs $eventArgs): void
+    {
+        $metadata = $eventArgs->getClassMetadata();
+
+        if (!$this->manager->getConfiguration()->isAudited($metadata->name)) {
+            $audited = false;
+            if ($metadata->rootEntityName === $metadata->name && ($metadata->isInheritanceTypeJoined() || $metadata->isInheritanceTypeSingleTable())) {
+                foreach ($metadata->subClasses as $subClass) {
+                    if ($this->manager->getConfiguration()->isAudited($subClass)) {
+                        $audited = true;
+                    }
+                }
+            }
+            if (!$audited) {
+                return;
+            }
+        }
+
+        if (!\in_array($metadata->inheritanceType, [
+            ClassMetadataInfo::INHERITANCE_TYPE_NONE,
+            ClassMetadataInfo::INHERITANCE_TYPE_JOINED,
+            ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE,
+        ], true)) {
+            throw new \Exception(sprintf('Inheritance type "%s" is not yet supported', $metadata->inheritanceType));
+        }
+
+        if ($this->reader->getEntityManager() === $this->manager->getConfiguration()->getEntityManager()) {
+            // default_entity_manager
+            $updater = new UpdateHelper($this->manager, $this->reader);
+            $updater->createAuditTable($eventArgs->getClassTable(), $eventArgs->getSchema());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            ToolEvents::postGenerateSchemaTable,
+        ];
+    }
+}

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -51,6 +51,12 @@ services:
     tags:
       - { name: doctrine.event_subscriber, connection: default }
 
+  dh_doctrine_audit.event_subscriber.create_schema:
+    class: DH\DoctrineAuditBundle\EventSubscriber\CreateSchemaListener
+    arguments: ["@dh_doctrine_audit.manager", "@dh_doctrine_audit.reader"]
+    tags:
+      - { name: doctrine.event_subscriber, connection: default }
+
   dh_doctrine_audit.twig_extension:
     class: DH\DoctrineAuditBundle\Twig\Extension\TwigExtension
     arguments: ['@doctrine']


### PR DESCRIPTION
The purpose of this PR is to bring back the `CreateSchemaListener` for single database setup only. This makes `doctrine:schema:update`, `doctrine:migrations:diff` and consequently `make:migration` take audit tables into consideration. This also should fix #91 