### PR TITLE
Annotation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "symfony/orm-pack": "^1.0",
     "symfony/security-bundle": "^3.4 || ^4.0",
     "pagerfanta/pagerfanta": "^2.1",
-    "white-october/pagerfanta-bundle": "^1.2"
+    "white-october/pagerfanta-bundle": "^1.2",
+    "doctrine/annotations": "^1.8"
   },
   "autoload": {
     "psr-4": {

--- a/src/DoctrineAuditBundle/Annotation/AnnotationLoader.php
+++ b/src/DoctrineAuditBundle/Annotation/AnnotationLoader.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Entity;
+
+class AnnotationLoader
+{
+    /**
+     * @var AnnotationReader
+     */
+    private $reader;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->reader = new AnnotationReader();
+    }
+
+    public function load(): array
+    {
+        $configuration = array();
+
+        $metadatas = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        foreach ($metadatas as $metadata) {
+            $config = $this->getEntityConfiguration($metadata);
+            if (null !== $config) {
+                $configuration[$metadata->getName()] = $config;
+            }
+        }
+
+        return $configuration;
+    }
+
+    private function getEntityConfiguration(ClassMetadata $metadata): ?array
+    {
+        $reflection = $metadata->getReflectionClass();
+
+        // Check that we have an Entity annotation
+        $annotation = $this->reader->getClassAnnotation($reflection, Entity::class);
+        if (null === $annotation) {
+            return null;
+        }
+
+        // Check that we have an Auditable annotation
+        $annotation = $this->reader->getClassAnnotation($reflection, Auditable::class);
+        if (null === $annotation) {
+            return null;
+        }
+
+        $config =  [
+            'ignored_columns' => [],
+            'enabled' => $annotation->enabled,
+        ];
+
+        // Are there any Ignore annotations?
+        foreach ($reflection->getProperties() as $property) {
+            if ($this->reader->getPropertyAnnotation($property, Ignore::class)) {
+                // TODO: $property->getName() might not be the column name
+                $config['ignored_columns'][] = $property->getName();
+            }
+        }
+
+        return $config;
+    }
+}

--- a/src/DoctrineAuditBundle/Annotation/Auditable.php
+++ b/src/DoctrineAuditBundle/Annotation/Auditable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ *
+ * @Target("CLASS")
+ */
+final class Auditable extends Annotation
+{
+    /**
+     * @var bool
+     */
+    public $enabled = true;
+}

--- a/src/DoctrineAuditBundle/Annotation/Ignore.php
+++ b/src/DoctrineAuditBundle/Annotation/Ignore.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ *
+ * @Target("PROPERTY")
+ */
+final class Ignore extends Annotation
+{
+}

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\Helper\DoctrineHelper;
 use DH\DoctrineAuditBundle\User\UserProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -60,17 +61,24 @@ class AuditConfiguration
      */
     private $entityManager;
 
+    /**
+     * @var AnnotationLoader
+     */
+    private $annotationLoader;
+
     public function __construct(
         array $config,
         UserProviderInterface $userProvider,
         RequestStack $requestStack,
         FirewallMap $firewallMap,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $entityManager,
+        AnnotationLoader $annotationLoader
     ) {
         $this->userProvider = $userProvider;
         $this->requestStack = $requestStack;
         $this->firewallMap = $firewallMap;
         $this->entityManager = $entityManager;
+        $this->annotationLoader = $annotationLoader;
 
         $this->enabled = $config['enabled'];
         $this->tablePrefix = $config['table_prefix'];
@@ -84,6 +92,11 @@ class AuditConfiguration
                 $this->entities[$auditedEntity] = $entityOptions;
             }
         }
+
+        // Update config using annotations
+        $config = $this->annotationLoader->load();
+        $this->entities = array_merge($this->entities, $config);
+dump($this->entities);
     }
 
     /**

--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -96,7 +96,6 @@ class AuditConfiguration
         // Update config using annotations
         $config = $this->annotationLoader->load();
         $this->entities = array_merge($this->entities, $config);
-dump($this->entities);
     }
 
     /**

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -1,8 +1,10 @@
 services:
-  dh_doctrine_audit.user_provider:
-    class: DH\DoctrineAuditBundle\User\TokenStorageUserProvider
-    arguments: ["@security.helper"]
-    public: true
+  dh_doctrine_audit.annotation_loader:
+    class: DH\DoctrineAuditBundle\Annotation\AnnotationLoader
+    arguments: ["@doctrine.orm.default_entity_manager"]
+
+  DH\DoctrineAuditBundle\Annotation\AnnotationLoader:
+    alias: dh_doctrine_audit.annotation_loader
 
   dh_doctrine_audit.configuration:
     class: DH\DoctrineAuditBundle\AuditConfiguration
@@ -12,11 +14,10 @@ services:
       - "@request_stack"
       - "@security.firewall.map"
       - "@doctrine.orm.default_entity_manager"
-    public: true
+      - "@dh_doctrine_audit.annotation_loader"
 
   DH\DoctrineAuditBundle\AuditConfiguration:
     alias: dh_doctrine_audit.configuration
-    public: true
 
   dh_doctrine_audit.reader:
     class: DH\DoctrineAuditBundle\Reader\AuditReader
@@ -32,18 +33,26 @@ services:
     arguments: ["@dh_doctrine_audit.configuration", "@dh_doctrine_audit.helper"]
     public: true
 
-  DH\DoctrineAuditBundle\AuditManager:
+  DH\DoctrineAuditBundle\Manager\AuditManager:
     alias: dh_doctrine_audit.manager
     public: true
 
   dh_doctrine_audit.helper:
     class: DH\DoctrineAuditBundle\Helper\AuditHelper
     arguments: ["@dh_doctrine_audit.configuration"]
-    public: true
 
   DH\DoctrineAuditBundle\Helper\AuditHelper:
     alias: dh_doctrine_audit.helper
-    public: true
+
+  dh_doctrine_audit.user_provider:
+    class: DH\DoctrineAuditBundle\User\TokenStorageUserProvider
+    arguments: ["@security.helper"]
+
+  dh_doctrine_audit.twig_extension:
+    class: DH\DoctrineAuditBundle\Twig\Extension\TwigExtension
+    arguments: ['@doctrine']
+    tags:
+      - { name: twig.extension }
 
   dh_doctrine_audit.event_subscriber.audit:
     class: DH\DoctrineAuditBundle\EventSubscriber\AuditSubscriber
@@ -56,12 +65,6 @@ services:
     arguments: ["@dh_doctrine_audit.manager", "@dh_doctrine_audit.reader"]
     tags:
       - { name: doctrine.event_subscriber, connection: default }
-
-  dh_doctrine_audit.twig_extension:
-    class: DH\DoctrineAuditBundle\Twig\Extension\TwigExtension
-    arguments: ['@doctrine']
-    tags:
-      - { name: twig.extension }
 
   dh_doctrine_audit.command.clean:
     class: DH\DoctrineAuditBundle\Command\CleanAuditLogsCommand

--- a/tests/DoctrineAuditBundle/AuditConfigurationTest.php
+++ b/tests/DoctrineAuditBundle/AuditConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Tests;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\AuditConfiguration;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Comment;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Post;
@@ -388,6 +389,7 @@ final class AuditConfigurationTest extends BaseTest
     protected function getAuditConfiguration(array $options = [], ?EntityManager $entityManager = null): AuditConfiguration
     {
         $container = new ContainerBuilder();
+        $em = $entityManager ?? $this->getEntityManager();
 
         return new AuditConfiguration(
             array_merge([
@@ -401,7 +403,8 @@ final class AuditConfigurationTest extends BaseTest
             new TokenStorageUserProvider(new Security($container)),
             new RequestStack(),
             new FirewallMap($container, []),
-            $entityManager ?? $this->getEntityManager()
+            $em,
+            new AnnotationLoader($em)
         );
     }
 

--- a/tests/DoctrineAuditBundle/BaseTest.php
+++ b/tests/DoctrineAuditBundle/BaseTest.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Tests;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\AuditConfiguration;
 use DH\DoctrineAuditBundle\EventSubscriber\AuditSubscriber;
 use DH\DoctrineAuditBundle\EventSubscriber\CreateSchemaListener;
@@ -180,6 +181,7 @@ abstract class BaseTest extends TestCase
     protected function createAuditConfiguration(array $options = [], ?EntityManager $entityManager = null): AuditConfiguration
     {
         $container = new ContainerBuilder();
+        $em = $entityManager ?? $this->getEntityManager();
 
         return new AuditConfiguration(
             array_merge([
@@ -193,7 +195,8 @@ abstract class BaseTest extends TestCase
             new TokenStorageUserProvider(new Security($container)),
             new RequestStack(),
             new FirewallMap($container, []),
-            $entityManager ?? $this->getEntityManager()
+            $em,
+            new AnnotationLoader($em)
         );
     }
 

--- a/tests/DoctrineAuditBundle/CoreTest.php
+++ b/tests/DoctrineAuditBundle/CoreTest.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Tests;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\AuditConfiguration;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Author;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Comment;
@@ -248,6 +249,8 @@ abstract class CoreTest extends BaseTest
         $requestStack = new RequestStack();
         $requestStack->push(new Request([], [], [], [], [], ['REMOTE_ADDR' => '1.2.3.4']));
 
+        $em = $entityManager ?? $this->getEntityManager();
+
         return new AuditConfiguration(
             array_merge([
                 'enabled' => true,
@@ -260,7 +263,8 @@ abstract class CoreTest extends BaseTest
             new TokenStorageUserProvider($security),
             $requestStack,
             new FirewallMap($container, []),
-            $entityManager ?? $this->getEntityManager()
+            $em,
+            new AnnotationLoader($em)
         );
     }
 }

--- a/tests/DoctrineAuditBundle/DHDoctrineAuditBundleTest.php
+++ b/tests/DoctrineAuditBundle/DHDoctrineAuditBundleTest.php
@@ -45,7 +45,7 @@ final class DHDoctrineAuditBundleTest extends TestCase
 
         $em = EntityManager::create(
             $connection,
-            Setup::createAnnotationMetadataConfiguration([])
+            Setup::createAnnotationMetadataConfiguration([__DIR__.'/Fixtures'])
         );
 
         $container->set('entity_manager', $em);

--- a/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Tests\Helper;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\AuditConfiguration;
 use DH\DoctrineAuditBundle\Helper\AuditHelper;
 use DH\DoctrineAuditBundle\Tests\CoreTest;
@@ -216,7 +217,8 @@ final class AuditHelperTest extends CoreTest
             $configuration->getUserProvider(),
             $configuration->getRequestStack(),
             new FirewallMap(new ContainerBuilder(), []),
-            $em
+            $em,
+            new AnnotationLoader($em)
         );
         $helper = new AuditHelper($configuration);
 
@@ -280,7 +282,8 @@ final class AuditHelperTest extends CoreTest
             $configuration->getUserProvider(),
             $configuration->getRequestStack(),
             new FirewallMap(new ContainerBuilder(), []),
-            $em
+            $em,
+            new AnnotationLoader($em)
         );
         $helper = new AuditHelper($configuration);
 
@@ -396,7 +399,8 @@ final class AuditHelperTest extends CoreTest
             $this->getAuditConfiguration()->getUserProvider(),
             new RequestStack(),
             new FirewallMap(new ContainerBuilder(), []),
-            $em
+            $em,
+            new AnnotationLoader($em)
         );
         $helper = new AuditHelper($configuration);
 
@@ -413,6 +417,7 @@ final class AuditHelperTest extends CoreTest
 
     public function testBlameWhenNoUser(): void
     {
+        $em = $this->getEntityManager();
         $configuration = new AuditConfiguration(
             [
                 'enabled' => true,
@@ -425,7 +430,8 @@ final class AuditHelperTest extends CoreTest
             new TokenStorageUserProvider(new Security(new ContainerBuilder())),
             new RequestStack(),
             new FirewallMap(new ContainerBuilder(), []),
-            $this->getEntityManager()
+            $em,
+            new AnnotationLoader($em)
         );
         $helper = new AuditHelper($configuration);
 

--- a/tests/DoctrineAuditBundle/Manager/AuditTransactionTest.php
+++ b/tests/DoctrineAuditBundle/Manager/AuditTransactionTest.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle\Tests\Manager;
 
+use DH\DoctrineAuditBundle\Annotation\AnnotationLoader;
 use DH\DoctrineAuditBundle\AuditConfiguration;
 use DH\DoctrineAuditBundle\Helper\AuditHelper;
 use DH\DoctrineAuditBundle\Manager\AuditManager;
@@ -59,6 +60,7 @@ final class AuditTransactionTest extends BaseTest
     protected function getAuditConfiguration(array $options = [], ?EntityManager $entityManager = null): AuditConfiguration
     {
         $container = new ContainerBuilder();
+        $em = $entityManager ?? $this->getEntityManager();
 
         return new AuditConfiguration(
             array_merge([
@@ -72,7 +74,8 @@ final class AuditTransactionTest extends BaseTest
             new TokenStorageUserProvider(new Security($container)),
             new RequestStack(),
             new FirewallMap($container, []),
-            $entityManager ?? $this->getEntityManager()
+            $em,
+            new AnnotationLoader($em)
         );
     }
 


### PR DESCRIPTION
Initial annotation support:
- Auditable: define an entity as auditable (supports `enabled` option)
- Ignore: exclude a property from auditing