### PR TITLE
symfony/lock required in non-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "symfony/security-bundle": "^3.4 || ^4.0",
     "pagerfanta/pagerfanta": "^2.1",
     "white-october/pagerfanta-bundle": "^1.2",
-    "doctrine/annotations": "^1.8"
+    "doctrine/annotations": "^1.8",
+    "symfony/lock": "^3.4 || ^4.0"
   },
   "autoload": {
     "psr-4": {
@@ -39,7 +40,6 @@
     "phpstan/phpstan-doctrine": "^0.11.1",
     "phpstan/phpstan-symfony": "^0.11.1",
     "twig/extensions": "^1.5",
-    "symfony/lock": "^4.2",
     "friendsofphp/php-cs-fixer": "^2.15"
   },
   "conflict": {

--- a/doc/50-audits-cleanup.md
+++ b/doc/50-audits-cleanup.md
@@ -1,7 +1,5 @@
 # Audits cleanup
 
-**Notice**: symfony/lock is required, to install it use `composer require symfony/lock`
-
 DoctrineAuditBundle provides a convenient command that helps you cleaning audit tables.
 Open a command console, enter your project directory and execute:
 


### PR DESCRIPTION
otherwise `audit:clean` and `audit:schema:update` can’t be executed