### PR TITLE
Allow multiple filters in `AuditReader::filterBy()`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,5 +17,4 @@ parameters:
         - '~Parameter \#1 \$name of method Symfony\\Component\\Console\\Command\\Command\:\:setName\(\) expects string, string\|null given~'
         - '~Parameter \#1 \$tableName of method Doctrine\\DBAL\\Schema\\Schema\:\:(has|get)Table\(\) expects string, string\|null given~'
         - '~Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Driver\\Statement\|int~'
-        - '~Call to an undefined method Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata\:\:get(Schema|Table)Name\(\)~'
         - '~Possibly invalid array key type object\|string~'

--- a/src/DoctrineAuditBundle/Manager/AuditManager.php
+++ b/src/DoctrineAuditBundle/Manager/AuditManager.php
@@ -83,7 +83,7 @@ class AuditManager
     {
         /** @var ClassMetadata $meta */
         $meta = $em->getClassMetadata(\get_class($entity));
-        $this->audit($em, [
+        $this->audit([
             'action' => 'insert',
             'blame' => $this->helper->blame(),
             'diff' => $this->helper->diff($em, $entity, $ch),
@@ -114,7 +114,7 @@ class AuditManager
         }
         /** @var ClassMetadata $meta */
         $meta = $em->getClassMetadata(\get_class($entity));
-        $this->audit($em, [
+        $this->audit([
             'action' => 'update',
             'blame' => $this->helper->blame(),
             'diff' => $diff,
@@ -141,7 +141,7 @@ class AuditManager
     {
         /** @var ClassMetadata $meta */
         $meta = $em->getClassMetadata(\get_class($entity));
-        $this->audit($em, [
+        $this->audit([
             'action' => 'remove',
             'blame' => $this->helper->blame(),
             'diff' => $this->helper->summarize($em, $entity, $id),
@@ -328,18 +328,17 @@ class AuditManager
             $data['diff']['table'] = $mapping['joinTable']['name'];
         }
 
-        $this->audit($em, $data);
+        $this->audit($data);
     }
 
     /**
      * Adds an entry to the audit table.
      *
-     * @param EntityManagerInterface $em
-     * @param array                  $data
+     * @param array $data
      *
      * @throws Exception
      */
-    private function audit(EntityManagerInterface $em, array $data): void
+    private function audit(array $data): void
     {
         $schema = $data['schema'] ? $data['schema'].'.' : '';
         $auditTable = $schema.$this->configuration->getTablePrefix().$data['table'].$this->configuration->getTableSuffix();

--- a/tests/DoctrineAuditBundle/Reader/AuditReaderTest.php
+++ b/tests/DoctrineAuditBundle/Reader/AuditReaderTest.php
@@ -28,34 +28,50 @@ final class AuditReaderTest extends CoreTest
         self::assertInstanceOf(AuditConfiguration::class, $reader->getConfiguration(), 'configuration instanceof AuditConfiguration::class');
     }
 
-    public function testFilterIsNullByDefault(): void
+    public function testFilterIsEmptyByDefault(): void
     {
         $reader = $this->getReader();
 
-        self::assertNull($reader->getFilter(), 'filter is null by default.');
+        self::assertSame([], $reader->getFilters(), 'filters is empty by default.');
     }
 
-    public function testFilterCanOnlyBePartOfAllowedValues(): void
+    public function testFilterIsEmptyIfNotPartOfAllowedValues(): void
     {
         $reader = $this->getReader();
 
         $reader->filterBy('UNKNOWN');
-        self::assertNull($reader->getFilter(), 'filter is null when AuditReader::filterBy() parameter is not an allowed value.');
+        self::assertSame([], $reader->getFilters(), 'filters is empty when AuditReader::filterBy() parameter is not an allowed value.');
+
+        $reader->filterBy(['UNKNOWN1', 'UNKNOWN2']);
+        self::assertSame([], $reader->getFilters(), 'filters is empty when AuditReader::filterBy() parameter is not an allowed value.');
+    }
+
+    public function testFilterSingleValue(): void
+    {
+        $reader = $this->getReader();
 
         $reader->filterBy(AuditReader::ASSOCIATE);
-        self::assertSame(AuditReader::ASSOCIATE, $reader->getFilter(), 'filter is not null when AuditReader::filterBy() parameter is an allowed value.');
+        self::assertSame([AuditReader::ASSOCIATE], $reader->getFilters(), 'filter is not empty when AuditReader::filterBy() parameter is an allowed value.');
 
         $reader->filterBy(AuditReader::DISSOCIATE);
-        self::assertSame(AuditReader::DISSOCIATE, $reader->getFilter(), 'filter is not null when AuditReader::filterBy() parameter is an allowed value.');
+        self::assertSame([AuditReader::DISSOCIATE], $reader->getFilters(), 'filter is not empty when AuditReader::filterBy() parameter is an allowed value.');
 
         $reader->filterBy(AuditReader::INSERT);
-        self::assertSame(AuditReader::INSERT, $reader->getFilter(), 'filter is not null when AuditReader::filterBy() parameter is an allowed value.');
+        self::assertSame([AuditReader::INSERT], $reader->getFilters(), 'filter is not empty when AuditReader::filterBy() parameter is an allowed value.');
 
         $reader->filterBy(AuditReader::REMOVE);
-        self::assertSame(AuditReader::REMOVE, $reader->getFilter(), 'filter is not null when AuditReader::filterBy() parameter is an allowed value.');
+        self::assertSame([AuditReader::REMOVE], $reader->getFilters(), 'filter is not empty when AuditReader::filterBy() parameter is an allowed value.');
 
         $reader->filterBy(AuditReader::UPDATE);
-        self::assertSame(AuditReader::UPDATE, $reader->getFilter(), 'filter is not null when AuditReader::filterBy() parameter is an allowed value.');
+        self::assertSame([AuditReader::UPDATE], $reader->getFilters(), 'filter is not empty when AuditReader::filterBy() parameter is an allowed value.');
+    }
+
+    public function testFilterMultipleValues(): void
+    {
+        $reader = $this->getReader();
+
+        $reader->filterBy([AuditReader::ASSOCIATE, AuditReader::DISSOCIATE]);
+        self::assertSame([AuditReader::ASSOCIATE, AuditReader::DISSOCIATE], $reader->getFilters(), 'filter is not null when AuditReader::filterBy() parameter is composed of allowed value.');
     }
 
     public function testGetEntityTableName(): void
@@ -168,9 +184,7 @@ final class AuditReaderTest extends CoreTest
         $audits = $reader->getAudits(Tag::class, null, 1, 50);
 
         $i = 0;
-//        $this->assertCount(14, $audits, 'result count is ok.');
         self::assertCount(15, $audits, 'result count is ok.');
-//        $this->assertCount(12, $audits, 'result count is ok.');
         self::assertSame(AuditReader::DISSOCIATE, $audits[$i++]->getType(), 'entry'.$i.' is a dissociate operation.');
         self::assertSame(AuditReader::DISSOCIATE, $audits[$i++]->getType(), 'entry'.$i.' is a dissociate operation.');
         self::assertSame(AuditReader::ASSOCIATE, $audits[$i++]->getType(), 'entry'.$i.' is an associate operation.');


### PR DESCRIPTION
This should address #123 feature request (filtering using multiple filters at once).