### PR TITLE
Ensures DoctrineSubscriber is registered first

### DIFF
--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -69,7 +69,7 @@ services:
     class: DH\DoctrineAuditBundle\Event\DoctrineSubscriber
     arguments: ["@dh_doctrine_audit.manager"]
     tags:
-      - { name: doctrine.event_subscriber, connection: default }
+      - { name: doctrine.event_subscriber, connection: default, priority: 1000000 }
 
   dh_doctrine_audit.event_subscriber.create_schema:
     class: DH\DoctrineAuditBundle\Event\CreateSchemaListener

--- a/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
@@ -42,7 +42,7 @@ final class DHDoctrineAuditExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('dh_doctrine_audit.event_subscriber.doctrine', DoctrineSubscriber::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('dh_doctrine_audit.event_subscriber.doctrine', 0, 'dh_doctrine_audit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('dh_doctrine_audit.event_subscriber.doctrine', 'doctrine.event_subscriber', ['connection' => 'default']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('dh_doctrine_audit.event_subscriber.doctrine', 'doctrine.event_subscriber', ['connection' => 'default', 'priority' => 1000000]);
 
         $this->assertContainerBuilderHasService('dh_doctrine_audit.twig_extension', TwigExtension::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('dh_doctrine_audit.twig_extension', 0, 'doctrine');


### PR DESCRIPTION
Makes sure the `onFlush` subscriber executes first by setting a very high priority.
This lets it can capture all entity mutations originating from other listeners (should fix #122)