### PR TITLE
Fix doc related to 4228267

### DIFF
--- a/doc/21-audit-configuration.md
+++ b/doc/21-audit-configuration.md
@@ -88,7 +88,7 @@ the viewer to display audits of an entity. It has to be included in the entity c
  * @ORM\Entity
  *
  * @Audit\Auditable
- * @Audit\Security(roles={"ROLE1", "ROLE2"})
+ * @Audit\Security(view={"ROLE1", "ROLE2"})
  */
 class MyEntity
 {
@@ -101,7 +101,7 @@ class MyEntity
 }
 ```
 The above example makes the audit viewer allow access (viewing) to `MyEntity` audits if 
-the logged in user is granted either `ROLE1` or `ROLE2`
+the logged in user is granted either `ROLE1` or `ROLE2`.
 
 
 ### Example using annotations
@@ -117,7 +117,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  *
  * @Audit\Auditable
- * @Audit\Security(roles={"ROLE1", "ROLE2"})
+ * @Audit\Security(view={"ROLE1", "ROLE2"})
  */
 class AuditedEntity
 {


### PR DESCRIPTION
4228267 renamed the "roles" attribute of Security annotation to "view". This PR fixes the corresponding documentation accordingly.