### PR TITLE
Update DoctrineHelper

### DIFF
--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -192,7 +192,7 @@ class AuditConfiguration
      */
     public function isAuditable($entity): bool
     {
-        $class = DoctrineHelper::getRealClass($entity);
+        $class = DoctrineHelper::getRealClassName($entity);
 
         // is $entity part of audited entities?
         if (!\array_key_exists($class, $this->getEntities())) {
@@ -216,7 +216,7 @@ class AuditConfiguration
             return false;
         }
 
-        $class = DoctrineHelper::getRealClass($entity);
+        $class = DoctrineHelper::getRealClassName($entity);
 
         // is $entity part of audited entities?
         if (!\array_key_exists($class, $this->getEntities())) {
@@ -260,7 +260,7 @@ class AuditConfiguration
             return false;
         }
 
-        $class = DoctrineHelper::getRealClass($entity);
+        $class = DoctrineHelper::getRealClassName($entity);
         $entityOptions = $this->getEntities()[$class];
 
         if (null === $entityOptions) {

--- a/src/DoctrineAuditBundle/Helper/DoctrineHelper.php
+++ b/src/DoctrineAuditBundle/Helper/DoctrineHelper.php
@@ -9,19 +9,35 @@ class DoctrineHelper
     /**
      * Gets the real class name of a class name that could be a proxy.
      *
-     * @param object|string $subject
+     * @param object|string $class
      *
      * @return string
+     *
+     * credits
+     * https://github.com/api-platform/core/blob/master/src/Util/ClassInfoTrait.php
      */
-    public static function getRealClass($subject): string
+    public static function getRealClassName($class): string
     {
-        $class = \is_object($subject) ? \get_class($subject) : $subject;
+        $class = \is_object($class) ? \get_class($class) : $class;
 
-        if (false === $pos = mb_strrpos($class, '\\'.Proxy::MARKER.'\\')) {
+        // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
+        // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
+        $positionCg = mb_strrpos($class, '\\__CG__\\');
+        $positionPm = mb_strrpos($class, '\\__PM__\\');
+        if ((false === $positionCg) &&
+            (false === $positionPm)) {
             return $class;
         }
+        if (false !== $positionCg) {
+            return mb_substr($class, $positionCg + 8);
+        }
+        $className = ltrim($class, '\\');
 
-        return mb_substr($class, $pos + Proxy::MARKER_LENGTH + 2);
+        return mb_substr(
+            $className,
+            8 + $positionPm,
+            mb_strrpos($className, '\\') - ($positionPm + 8)
+        );
     }
 
     /**

--- a/src/DoctrineAuditBundle/Helper/DoctrineHelper.php
+++ b/src/DoctrineAuditBundle/Helper/DoctrineHelper.php
@@ -39,17 +39,4 @@ class DoctrineHelper
             mb_strrpos($className, '\\') - ($positionPm + 8)
         );
     }
-
-    /**
-     * Given a class name and a proxy namespace returns the proxy name.
-     *
-     * @param string $className
-     * @param string $proxyNamespace
-     *
-     * @return string
-     */
-    public static function generateProxyClassName($className, $proxyNamespace): string
-    {
-        return rtrim($proxyNamespace, '\\').'\\'.Proxy::MARKER.'\\'.ltrim($className, '\\');
-    }
 }

--- a/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
@@ -11,18 +11,12 @@ use PHPUnit\Framework\TestCase;
  */
 final class DoctrineHelperTest extends TestCase
 {
-    public function testGenerateProxyClassName(): void
-    {
-        self::assertSame('DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\__CG__\Post', DoctrineHelper::generateProxyClassName('Post', mb_substr(Post::class, 0, mb_strrpos(Post::class, '\\'))));
-    }
-
     /**
-     * @depends testGenerateProxyClassName
+     * 
      */
     public function testGetRealName(): void
     {
         self::assertNotSame('Post', DoctrineHelper::getRealClassName(Post::class));
         self::assertSame(Post::class, DoctrineHelper::getRealClassName(Post::class));
-        self::assertSame(Post::class, DoctrineHelper::getRealClassName(DoctrineHelper::generateProxyClassName(Post::class, mb_substr(Post::class, 0, mb_strrpos(Post::class, '\\')))));
     }
 }

--- a/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
@@ -3,6 +3,7 @@
 namespace DH\DoctrineAuditBundle\Tests\Helper;
 
 use DH\DoctrineAuditBundle\Helper\DoctrineHelper;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post;
 use PHPUnit\Framework\TestCase;
 
@@ -11,12 +12,31 @@ use PHPUnit\Framework\TestCase;
  */
 final class DoctrineHelperTest extends TestCase
 {
-    /**
-     * 
-     */
     public function testGetRealName(): void
     {
         self::assertNotSame('Post', DoctrineHelper::getRealClassName(Post::class));
+        self::assertNotSame('Comment', DoctrineHelper::getRealClassName(Comment::class));
+
         self::assertSame(Post::class, DoctrineHelper::getRealClassName(Post::class));
+        self::assertSame(Comment::class, DoctrineHelper::getRealClassName(Comment::class));
+
+        self::assertSame('DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post', DoctrineHelper::getRealClassName(Post::class));
+        self::assertSame('DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment', DoctrineHelper::getRealClassName(Comment::class));
+
+        $post = new Post();
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName($post));
+
+        $comment = new Comment();
+        self::assertSame(Comment::class, DoctrineHelper::getRealClassName($comment));
+
+        // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName('Proxies\__CG__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post'));
+        self::assertSame(Comment::class, DoctrineHelper::getRealClassName('Proxies\__CG__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment'));
+
+        // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName('ProxyManagerGeneratedProxy\__PM__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post\Generated309fa39f737280002e5d4e613b403125'));
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName('MongoDBODMProxies\__PM__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post\Generated309fa39f737280002e5d4e613b403125'));
+        self::assertSame(Comment::class, DoctrineHelper::getRealClassName('ProxyManagerGeneratedProxy\__PM__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment\Generated309fa39f737280002e5d4e613b403125'));
+        self::assertSame(Comment::class, DoctrineHelper::getRealClassName('MongoDBODMProxies\__PM__\DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment\Generated309fa39f737280002e5d4e613b403125'));
     }
 }

--- a/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/DoctrineHelperTest.php
@@ -21,8 +21,8 @@ final class DoctrineHelperTest extends TestCase
      */
     public function testGetRealName(): void
     {
-        self::assertNotSame('Post', DoctrineHelper::getRealClass(Post::class));
-        self::assertSame(Post::class, DoctrineHelper::getRealClass(Post::class));
-        self::assertSame(Post::class, DoctrineHelper::getRealClass(DoctrineHelper::generateProxyClassName(Post::class, mb_substr(Post::class, 0, mb_strrpos(Post::class, '\\')))));
+        self::assertNotSame('Post', DoctrineHelper::getRealClassName(Post::class));
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName(Post::class));
+        self::assertSame(Post::class, DoctrineHelper::getRealClassName(DoctrineHelper::generateProxyClassName(Post::class, mb_substr(Post::class, 0, mb_strrpos(Post::class, '\\')))));
     }
 }


### PR DESCRIPTION
remove DoctrineHelper as it's a duplicate of Doctrine Common ClassUtils, 

Have a look a [this discussion](https://github.com/doctrine/common/issues/826#issuecomment-472456562) and this is the class which will substitute [the Common ClassUtils]
(https://github.com/Ocramius/ProxyManager/blob/addb7d39c990d3d2299315f0200e78ebe658cd7a/src/ProxyManager/Inflector/ClassNameInflector.php#L41)

