### PR TITLE
Bug fix in Paginator when filters are used

### DIFF
--- a/src/DoctrineAuditBundle/Reader/Paginator.php
+++ b/src/DoctrineAuditBundle/Reader/Paginator.php
@@ -62,7 +62,7 @@ class Paginator implements Countable, IteratorAggregate
     {
         /** @var QueryBuilder $cloneQuery */
         $cloneQuery = clone $queryBuilder;
-        $cloneQuery->setParameters($queryBuilder->getParameters());
+        $cloneQuery->setParameters($queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
 
         return $cloneQuery;
     }


### PR DESCRIPTION
Specify parameter types when cloning a query builder in Paginator (fixes #150)