### PR TITLE
Localization: add translations for twig templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "symfony/translation": "^3.4|^4.0|^5.0",
     "symfony/twig-bundle": "^3.4|^4.0|^5.0",
     "doctrine/annotations": "^1.8",
-    "symfony/lock": "^3.4|^4.0|^5.0"
+    "symfony/lock": "^3.4|^4.0|^5.0",
+    "symfony/translation": "^3.4|^4.0|^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/DoctrineAuditBundle/Resources/config/translations.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/translations.yaml
@@ -1,0 +1,4 @@
+framework:
+  default_locale: 'en'
+  translator:
+    default_path: '%kernel.project_dir%/translations'

--- a/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
@@ -8,15 +8,15 @@
     <div class="card-body">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item active"><a href="{{ path('dh_doctrine_audit_list_audits') }}">Home</a></li>
+                <li class="breadcrumb-item active"><a href="{{ path('dh_doctrine_audit_list_audits') }}">{% trans %}home{% endtrans %}</a></li>
             </ol>
         </nav>
-        <h4 class="card-title">{{ audited|length }} audited entities</h4>
+        <h4 class="card-title">{{ audited|length }} {% trans %}audited_entities{% endtrans %}</h4>
         <table class="table table-hover">
             <thead class="thead-dark">
-            <th>Entity</th>
-            <th>Table</th>
-            <th>Activity</th>
+            <th>{% trans %}entity{% endtrans %}</th>
+            <th>{% trans %}table{% endtrans %}</th>
+            <th>{% trans %}activity{% endtrans %}</th>
             <th width="10%"></th>
             </thead>
             <tbody>
@@ -26,7 +26,7 @@
                     <td>{{ table|escape }}</td>
                     <td>{{ bootstrap.badge(reader.getAuditsCount(entity) ~ ' operations') }}</td>
                     <td>
-                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">View audits</a>
+                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">{% trans %}view_audit{% endtrans %}</a>
                     </td>
                 </tr>
             {% endfor %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
@@ -14,9 +14,9 @@
         <h4 class="card-title">{{ audited|length }} {% trans %}audit.header.audited_entities{% endtrans %}</h4>
         <table class="table table-hover">
             <thead class="thead-dark">
-            <th>{% trans %}audit.tableHeaders.entity{% endtrans %}</th>
-            <th>{% trans %}audit.tableHeaders.table{% endtrans %}</th>
-            <th>{% trans %}audit.tableHeaders.activity{% endtrans %}</th>
+            <th>{% trans %}audit.table_headers.entity{% endtrans %}</th>
+            <th>{% trans %}audit.table_headers.table{% endtrans %}</th>
+            <th>{% trans %}audit.table_headers.activity{% endtrans %}</th>
             <th width="10%"></th>
             </thead>
             <tbody>
@@ -26,7 +26,7 @@
                     <td>{{ table|escape }}</td>
                     <td>{{ bootstrap.badge(reader.getAuditsCount(entity) ~ ' operations') }}</td>
                     <td>
-                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">{% trans %}audit.auditDetails.view_audit{% endtrans %}</a>
+                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">{% trans %}audit.audit_details.view_audit{% endtrans %}</a>
                     </td>
                 </tr>
             {% endfor %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/audits.html.twig
@@ -8,15 +8,15 @@
     <div class="card-body">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item active"><a href="{{ path('dh_doctrine_audit_list_audits') }}">{% trans %}home{% endtrans %}</a></li>
+                <li class="breadcrumb-item active"><a href="{{ path('dh_doctrine_audit_list_audits') }}">{% trans %}audit.header.home{% endtrans %}</a></li>
             </ol>
         </nav>
-        <h4 class="card-title">{{ audited|length }} {% trans %}audited_entities{% endtrans %}</h4>
+        <h4 class="card-title">{{ audited|length }} {% trans %}audit.header.audited_entities{% endtrans %}</h4>
         <table class="table table-hover">
             <thead class="thead-dark">
-            <th>{% trans %}entity{% endtrans %}</th>
-            <th>{% trans %}table{% endtrans %}</th>
-            <th>{% trans %}activity{% endtrans %}</th>
+            <th>{% trans %}audit.tableHeaders.entity{% endtrans %}</th>
+            <th>{% trans %}audit.tableHeaders.table{% endtrans %}</th>
+            <th>{% trans %}audit.tableHeaders.activity{% endtrans %}</th>
             <th width="10%"></th>
             </thead>
             <tbody>
@@ -26,7 +26,7 @@
                     <td>{{ table|escape }}</td>
                     <td>{{ bootstrap.badge(reader.getAuditsCount(entity) ~ ' operations') }}</td>
                     <td>
-                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">{% trans %}view_audit{% endtrans %}</a>
+                        <a href="{{ path('dh_doctrine_audit_show_entity_history', {'entity': helper.namespaceToParam(entity)}) }}">{% trans %}audit.auditDetails.view_audit{% endtrans %}</a>
                     </td>
                 </tr>
             {% endfor %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -17,7 +17,7 @@
             </ol>
         </nav>
 
-        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>(most recent first)</em></h4>
+        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>{% trans %}most_recent{% endtrans %}</em></h4>
         <h5 class="float-right">{{ bootstrap.badge(paginator.results|length ~ ' operations', 'primary') }}</h5>
 
         <div class="timeline-centered">

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -17,7 +17,7 @@
             </ol>
         </nav>
 
-        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>{% trans %}audit.auditDetails.most_recent{% endtrans %}</em></h4>
+        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>{% trans %}audit.audit_details.most_recent{% endtrans %}</em></h4>
         <h5 class="float-right">{{ bootstrap.badge(paginator.results|length ~ ' operations', 'primary') }}</h5>
 
         <div class="timeline-centered">

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entity_history.html.twig
@@ -9,7 +9,7 @@
     <div class="card-body">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="{{ path('dh_doctrine_audit_list_audits') }}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{{ path('dh_doctrine_audit_list_audits') }}">{% trans %}audit.header.home{% endtrans %}</a></li>
                 <li class="breadcrumb-item {% if id is null %}active{% endif %}" aria-current="page"><a href="{{ path('dh_doctrine_audit_show_entity_history', { 'entity': helper.namespaceToParam(entity) }) }}">{{ entity }}</a></li>
                 {% if id is not null %}
                 <li class="breadcrumb-item active" aria-current="page"><a href="{{ path('dh_doctrine_audit_show_entity_history', { 'entity': helper.namespaceToParam(entity), 'id': id }) }}">{{ entity }}#{{ id }}</a></li>
@@ -17,7 +17,7 @@
             </ol>
         </nav>
 
-        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>{% trans %}most_recent{% endtrans %}</em></h4>
+        <h4 class="card-title float-left"><code>{{ entity }}{% if id is not null %}#{{ id }}{% endif %}</code> <em>{% trans %}audit.auditDetails.most_recent{% endtrans %}</em></h4>
         <h5 class="float-right">{{ bootstrap.badge(paginator.results|length ~ ' operations', 'primary') }}</h5>
 
         <div class="timeline-centered">

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
@@ -16,7 +16,7 @@
                 <div class="col-lg-8"><h2 class="mb-0">{{ helper.humanize(entity, entry) }}</h2></div>
                 <div class="col-lg-3" align="right">
                     {% if entry.transaction_hash is not empty %}
-                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="{% trans %}audit.auditDetails.entry_title{% endtrans %}">
+                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="{% trans %}audit.audit_details.entry_title{% endtrans %}">
                         <i class="fas fa-tag"></i>&nbsp;{{ entry.transaction_hash }}
                     </a>
                     {% endif %}
@@ -26,9 +26,9 @@
             {% if entry.type in ['insert', 'update'] %}
                 <table class="table table-hover layout-fixed table-sm mt-2 mb-0">
                     <thead class="thead-light">
-                    <th width="30%">{% trans %}audit.auditDetails.property{% endtrans %}</th>
-                    <th width="35%">{% trans %}audit.auditDetails.old_value{% endtrans %}</th>
-                    <th width="35%">{% trans %}audit.auditDetails.new_value{% endtrans %}</th>
+                    <th width="30%">{% trans %}audit.audit_details.property{% endtrans %}</th>
+                    <th width="35%">{% trans %}audit.audit_details.old_value{% endtrans %}</th>
+                    <th width="35%">{% trans %}audit.audit_details.new_value{% endtrans %}</th>
                     </thead>
                     <tbody>
                     {% set diffs = entry.diffs|json_decode(true) %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
@@ -16,7 +16,7 @@
                 <div class="col-lg-8"><h2 class="mb-0">{{ helper.humanize(entity, entry) }}</h2></div>
                 <div class="col-lg-3" align="right">
                     {% if entry.transaction_hash is not empty %}
-                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="View all operations within this transaction">
+                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="{% trans %}entry_title{% endtrans %}">
                         <i class="fas fa-tag"></i>&nbsp;{{ entry.transaction_hash }}
                     </a>
                     {% endif %}
@@ -26,9 +26,9 @@
             {% if entry.type in ['insert', 'update'] %}
                 <table class="table table-hover layout-fixed table-sm mt-2 mb-0">
                     <thead class="thead-light">
-                    <th width="30%">Property</th>
-                    <th width="35%">Old value</th>
-                    <th width="35%">New value</th>
+                    <th width="30%">{% trans %}property{% endtrans %}</th>
+                    <th width="35%">{% trans %}old_value{% endtrans %}</th>
+                    <th width="35%">{% trans %}new_value{% endtrans %}</th>
                     </thead>
                     <tbody>
                     {% set diffs = entry.diffs|json_decode(true) %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
@@ -16,7 +16,7 @@
                 <div class="col-lg-8"><h2 class="mb-0">{{ helper.humanize(entity, entry) }}</h2></div>
                 <div class="col-lg-3" align="right">
                     {% if entry.transaction_hash is not empty %}
-                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="{% trans %}entry_title{% endtrans %}">
+                    <a href="{{ path('dh_doctrine_audit_show_transaction', {hash: entry.transaction_hash}) }}" class="badge badge-pill badge-light font-weight-light transaction-hash" title="{% trans %}audit.auditDetails.entry_title{% endtrans %}">
                         <i class="fas fa-tag"></i>&nbsp;{{ entry.transaction_hash }}
                     </a>
                     {% endif %}
@@ -26,9 +26,9 @@
             {% if entry.type in ['insert', 'update'] %}
                 <table class="table table-hover layout-fixed table-sm mt-2 mb-0">
                     <thead class="thead-light">
-                    <th width="30%">{% trans %}property{% endtrans %}</th>
-                    <th width="35%">{% trans %}old_value{% endtrans %}</th>
-                    <th width="35%">{% trans %}new_value{% endtrans %}</th>
+                    <th width="30%">{% trans %}audit.auditDetails.property{% endtrans %}</th>
+                    <th width="35%">{% trans %}audit.auditDetails.old_value{% endtrans %}</th>
+                    <th width="35%">{% trans %}audit.auditDetails.new_value{% endtrans %}</th>
                     </thead>
                     <tbody>
                     {% set diffs = entry.diffs|json_decode(true) %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/helpers/pager.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/helpers/pager.html.twig
@@ -27,17 +27,17 @@
 
 {% macro first(entity, paginator) %}
     {% if paginator.hasPreviousPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: 1}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-double-left"></i> {% trans %}first{% endtrans %}</a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: 1}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-double-left"></i> {% trans %}audit.pager.first{% endtrans %}</a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-double-left"></i> {% trans %}first{% endtrans %}</span></li>
+        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-double-left"></i> {% trans %}audit.pager.first{% endtrans %}</span></li>
     {% endif %}
 {% endmacro first %}
 
 {% macro previous(entity, paginator) %}
     {% if paginator.hasPreviousPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.previousPage}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-left"></i> {% trans %}previous{% endtrans %}</a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.previousPage}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-left"></i> {% trans %}audit.pager.previous{% endtrans %}</a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-left"></i> {% trans %}previous{% endtrans %}</span></li>
+        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-left"></i> {% trans %}audit.pager.previous{% endtrans %}</span></li>
     {% endif %}
 {% endmacro previous %}
 
@@ -61,23 +61,23 @@
 
 {% macro next(entity, paginator) %}
     {% if paginator.hasNextPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.nextPage}) }}" class="page-link" rel="next">{% trans %}next{% endtrans %} <i class="fa fw fa-angle-right"></i></a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.nextPage}) }}" class="page-link" rel="next">{% trans %}audit.pager.next{% endtrans %} <i class="fa fw fa-angle-right"></i></a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link">{% trans %}next{% endtrans %} <i class="fa fw fa-angle-right"></i></span></li>
+        <li class="page-item disabled"><span class="page-link">{% trans %}audit.pager.next{% endtrans %} <i class="fa fw fa-angle-right"></i></span></li>
     {% endif %}
 {% endmacro next %}
 
 {% macro last(entity, paginator) %}
     {% if paginator.hasNextPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.numPages}) }}" class="page-link" rel="previous">{% trans %}last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.numPages}) }}" class="page-link" rel="previous">{% trans %}audit.pager.last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link">{% trans %}last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></span></li>
+        <li class="page-item disabled"><span class="page-link">{% trans %}audit.pager.last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></span></li>
     {% endif %}
 {% endmacro last %}
 
 {% macro page(entity, paginator, page) %}
     {% if page == paginator.currentPage %}
-        <li class="page-item active"><span class="page-link">{{ page }} <span class="sr-only">{% trans %}current{% endtrans %}</span></span></li>
+        <li class="page-item active"><span class="page-link">{{ page }} <span class="sr-only">{% trans %}audit.pager.current{% endtrans %}</span></span></li>
     {% else %}
         <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: page}) }}" class="page-link">{{ page }}</a></li>
     {% endif %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/helpers/pager.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/helpers/pager.html.twig
@@ -27,17 +27,17 @@
 
 {% macro first(entity, paginator) %}
     {% if paginator.hasPreviousPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: 1}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-double-left"></i> First</a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: 1}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-double-left"></i> {% trans %}first{% endtrans %}</a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-double-left"></i> First</span></li>
+        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-double-left"></i> {% trans %}first{% endtrans %}</span></li>
     {% endif %}
 {% endmacro first %}
 
 {% macro previous(entity, paginator) %}
     {% if paginator.hasPreviousPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.previousPage}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-left"></i> Previous</a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.previousPage}) }}" class="page-link" rel="previous"><i class="fa fw fa-angle-left"></i> {% trans %}previous{% endtrans %}</a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-left"></i> Previous</span></li>
+        <li class="page-item disabled"><span class="page-link"><i class="fa fw fa-angle-left"></i> {% trans %}previous{% endtrans %}</span></li>
     {% endif %}
 {% endmacro previous %}
 
@@ -61,23 +61,23 @@
 
 {% macro next(entity, paginator) %}
     {% if paginator.hasNextPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.nextPage}) }}" class="page-link" rel="next">Next <i class="fa fw fa-angle-right"></i></a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.nextPage}) }}" class="page-link" rel="next">{% trans %}next{% endtrans %} <i class="fa fw fa-angle-right"></i></a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link">Next <i class="fa fw fa-angle-right"></i></span></li>
+        <li class="page-item disabled"><span class="page-link">{% trans %}next{% endtrans %} <i class="fa fw fa-angle-right"></i></span></li>
     {% endif %}
 {% endmacro next %}
 
 {% macro last(entity, paginator) %}
     {% if paginator.hasNextPage %}
-        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.numPages}) }}" class="page-link" rel="previous">Last <i class="fa fw fa-angle-double-right"></i></a></li>
+        <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: paginator.numPages}) }}" class="page-link" rel="previous">{% trans %}last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></a></li>
     {% else %}
-        <li class="page-item disabled"><span class="page-link">Last <i class="fa fw fa-angle-double-right"></i></span></li>
+        <li class="page-item disabled"><span class="page-link">{% trans %}last{% endtrans %} <i class="fa fw fa-angle-double-right"></i></span></li>
     {% endif %}
 {% endmacro last %}
 
 {% macro page(entity, paginator, page) %}
     {% if page == paginator.currentPage %}
-        <li class="page-item active"><span class="page-link">{{ page }} <span class="sr-only">(current)</span></span></li>
+        <li class="page-item active"><span class="page-link">{{ page }} <span class="sr-only">{% trans %}current{% endtrans %}</span></span></li>
     {% else %}
         <li class="page-item"><a href="{{ path('dh_doctrine_audit_show_entity_history', {entity: entity, page: page}) }}" class="page-link">{{ page }}</a></li>
     {% endif %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
@@ -9,11 +9,11 @@
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ path('dh_doctrine_audit_list_audits') }}">Home</a></li>
-                    <li class="breadcrumb-item active" aria-current="page"><a href="{{ path('dh_doctrine_audit_show_transaction', {hash: hash}) }}">Transaction #{{ hash }}</a></li>
+                    <li class="breadcrumb-item active" aria-current="page"><a href="{{ path('dh_doctrine_audit_show_transaction', {hash: hash}) }}">{% trans %}transaction{% endtrans %} #{{ hash }}</a></li>
                 </ol>
             </nav>
 
-            <h4 class="card-title float-left"><code>Transaction #{{ hash }}</code> <em>(entity per entity)</em></h4>
+            <h4 class="card-title float-left"><code>{% trans %}transaction{% endtrans %} #{{ hash }}</code> <em>{% trans %}entity_per_entity{% endtrans %}</em></h4>
             {% set amount = 0 %}
             {% for entity, entries in audits %}
                 {% set amount = amount + entries|length %}
@@ -23,7 +23,7 @@
 
             {% for entity, entries in audits %}
             <hr class="mt-0" />
-            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>(most recent first)</em></h4>
+            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>{% trans %}most_recent{% endtrans %}</em></h4>
             <h5 class="float-right">{{ bootstrap.badge(entries|length ~ ' operations', 'primary') }}</h5>
             <div class="timeline-centered">
                 {% for entry in entries %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
@@ -13,7 +13,7 @@
                 </ol>
             </nav>
 
-            <h4 class="card-title float-left"><code>{% trans %}audit.auditDetails.transaction{% endtrans %} #{{ hash }}</code> <em>{% trans %}audit.auditDetails.entity_per_entity{% endtrans %}</em></h4>
+            <h4 class="card-title float-left"><code>{% trans %}audit.audit_details.transaction{% endtrans %} #{{ hash }}</code> <em>{% trans %}audit.audit_details.entity_per_entity{% endtrans %}</em></h4>
             {% set amount = 0 %}
             {% for entity, entries in audits %}
                 {% set amount = amount + entries|length %}
@@ -23,7 +23,7 @@
 
             {% for entity, entries in audits %}
             <hr class="mt-0" />
-            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>{% trans %}audit.auditDetails.most_recent{% endtrans %}</em></h4>
+            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>{% trans %}audit.audit_details.most_recent{% endtrans %}</em></h4>
             <h5 class="float-right">{{ bootstrap.badge(entries|length ~ ' operations', 'primary') }}</h5>
             <div class="timeline-centered">
                 {% for entry in entries %}

--- a/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/transaction.html.twig
@@ -8,12 +8,12 @@
         <div class="card-body">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{{ path('dh_doctrine_audit_list_audits') }}">Home</a></li>
+                    <li class="breadcrumb-item"><a href="{{ path('dh_doctrine_audit_list_audits') }}">{% trans %}audit.header.home{% endtrans %}</a></li>
                     <li class="breadcrumb-item active" aria-current="page"><a href="{{ path('dh_doctrine_audit_show_transaction', {hash: hash}) }}">{% trans %}transaction{% endtrans %} #{{ hash }}</a></li>
                 </ol>
             </nav>
 
-            <h4 class="card-title float-left"><code>{% trans %}transaction{% endtrans %} #{{ hash }}</code> <em>{% trans %}entity_per_entity{% endtrans %}</em></h4>
+            <h4 class="card-title float-left"><code>{% trans %}audit.auditDetails.transaction{% endtrans %} #{{ hash }}</code> <em>{% trans %}audit.auditDetails.entity_per_entity{% endtrans %}</em></h4>
             {% set amount = 0 %}
             {% for entity, entries in audits %}
                 {% set amount = amount + entries|length %}
@@ -23,7 +23,7 @@
 
             {% for entity, entries in audits %}
             <hr class="mt-0" />
-            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>{% trans %}most_recent{% endtrans %}</em></h4>
+            <h4 class="card-title float-left"><code>{{ entity }}</code> <em>{% trans %}audit.auditDetails.most_recent{% endtrans %}</em></h4>
             <h5 class="float-right">{{ bootstrap.badge(entries|length ~ ' operations', 'primary') }}</h5>
             <div class="timeline-centered">
                 {% for entry in entries %}

--- a/src/DoctrineAuditBundle/translations/messages.de.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.de.yaml
@@ -2,11 +2,11 @@ audit:
   header:
     home: Home
     audited_entities: geprüfte Unternehmen
-  tableHeaders:
+  table_headers:
     entity: Einheit
     table: Tabelle
     activity: Aktivität
-  auditDetails:
+  audit_details:
     view_audit: Audits anzeigen
     most_recent: (neueste zuerst)
     entry_title: Alle Operationen in dieser Transaktion anzeigen

--- a/src/DoctrineAuditBundle/translations/messages.de.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.de.yaml
@@ -1,0 +1,18 @@
+home: Home
+audited_entities: geprüfte Unternehmen
+entity: Einheit
+table: Tabelle
+activity: Aktivität
+view_audit: Audits anzeigen
+most_recent: (neueste zuerst)
+entry_title: Alle Operationen in dieser Transaktion anzeigen
+property: Eigentum
+old_value: Alter Wert
+new_value: Neuer Wert
+transaction: Transaktion
+entity_per_entity: (Entität pro Entität)
+first: Zuerst
+previous: Vorherige
+last: Letzte
+next: Weiter
+curreent:  aktuell

--- a/src/DoctrineAuditBundle/translations/messages.de.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.de.yaml
@@ -1,18 +1,24 @@
-home: Home
-audited_entities: geprüfte Unternehmen
-entity: Einheit
-table: Tabelle
-activity: Aktivität
-view_audit: Audits anzeigen
-most_recent: (neueste zuerst)
-entry_title: Alle Operationen in dieser Transaktion anzeigen
-property: Eigentum
-old_value: Alter Wert
-new_value: Neuer Wert
-transaction: Transaktion
-entity_per_entity: (Entität pro Entität)
-first: Zuerst
-previous: Vorherige
-last: Letzte
-next: Weiter
-curreent:  aktuell
+audit:
+  header:
+    home: Home
+    audited_entities: geprüfte Unternehmen
+  tableHeaders:
+    entity: Einheit
+    table: Tabelle
+    activity: Aktivität
+  auditDetails:
+    view_audit: Audits anzeigen
+    most_recent: (neueste zuerst)
+    entry_title: Alle Operationen in dieser Transaktion anzeigen
+    property: Eigentum
+    old_value: Alter Wert
+    new_value: Neuer Wert
+    transaction: Transaktion
+    entity_per_entity: (Entität pro Entität)
+  pager:
+    first: Zuerst
+    previous: Vorherige
+    last: Letzte
+    next: Weiter
+    current: aktuell
+

--- a/src/DoctrineAuditBundle/translations/messages.en.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.en.yaml
@@ -1,0 +1,18 @@
+home: Home
+audited_entities: audited entities
+entity: Entity
+table: Table
+activity: Activity
+view_audit: View audits
+most_recent: (most recent first)
+entry_title: View all operations within this transaction
+property: Property
+old_value: Old value
+new_value: New value
+transaction: Transaction
+entity_per_entity: (entity per entity)
+first: First
+previous: Previous
+last: Last
+next: Next
+curreent:  current

--- a/src/DoctrineAuditBundle/translations/messages.en.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.en.yaml
@@ -1,18 +1,24 @@
-home: Home
-audited_entities: audited entities
-entity: Entity
-table: Table
-activity: Activity
-view_audit: View audits
-most_recent: (most recent first)
-entry_title: View all operations within this transaction
-property: Property
-old_value: Old value
-new_value: New value
-transaction: Transaction
-entity_per_entity: (entity per entity)
-first: First
-previous: Previous
-last: Last
-next: Next
-curreent:  current
+audit:
+  header:
+    home: Home
+    audited_entities: audited entities
+  tableHeaders:
+    entity: Entity
+    table: Table
+    activity: Activity
+  auditDetails:
+    view_audit: Visualizza audit
+    most_recent: (most recent first)
+    entry_title: View all operations within this transaction
+    property: Property
+    old_value: Old value
+    new_value: New value
+    transaction: Transaction
+    entity_per_entity: (entity per entity)
+  pager:
+    first: First
+    previous: Previous
+    last: Last
+    next: Next
+    current: Current
+

--- a/src/DoctrineAuditBundle/translations/messages.en.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.en.yaml
@@ -2,11 +2,11 @@ audit:
   header:
     home: Home
     audited_entities: audited entities
-  tableHeaders:
+  table_headers:
     entity: Entity
     table: Table
     activity: Activity
-  auditDetails:
+  audit_details:
     view_audit: Visualizza audit
     most_recent: (most recent first)
     entry_title: View all operations within this transaction

--- a/src/DoctrineAuditBundle/translations/messages.es.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.es.yaml
@@ -1,0 +1,18 @@
+home: Home
+audited_entities: entidades auditadas
+entity: Entidad
+table: Tabla
+activity: Actividad
+view_audit: ver audit
+most_recent: (el más reciente primero)
+entry_title: Ver todas las operaciones dentro de esta transacción
+property: Propiedad
+old_value: viejo valor
+new_value: nuevo valor
+transaction: Transacción
+entity_per_entity: (entidad por entidad)
+first: Primero
+previous: Anterior
+last: Ultimo
+next: Siguente
+curreent:  actual

--- a/src/DoctrineAuditBundle/translations/messages.es.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.es.yaml
@@ -1,18 +1,24 @@
-home: Home
-audited_entities: entidades auditadas
-entity: Entidad
-table: Tabla
-activity: Actividad
-view_audit: ver audit
-most_recent: (el más reciente primero)
-entry_title: Ver todas las operaciones dentro de esta transacción
-property: Propiedad
-old_value: viejo valor
-new_value: nuevo valor
-transaction: Transacción
-entity_per_entity: (entidad por entidad)
-first: Primero
-previous: Anterior
-last: Ultimo
-next: Siguente
-curreent:  actual
+audit:
+  header:
+    home: Home
+    audited_entities: entidades auditadas
+  tableHeaders:
+    entity: Entidad
+    table: Tabla
+    activity: Actividad
+  auditDetails:
+    view_audit: Ver audit
+    most_recent:  (el más reciente primero)
+    entry_title: Ver todas las operaciones dentro de esta transacción
+    property: Propiedad
+    old_value: Viejo valor
+    new_value: Nuevo valor
+    transaction: Transacción
+    entity_per_entity: (entidad por entidad)
+  pager:
+    first: Primero
+    previous: Anterior
+    last: Ultimo
+    next: Siguente
+    current:  Actual
+

--- a/src/DoctrineAuditBundle/translations/messages.es.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.es.yaml
@@ -2,11 +2,11 @@ audit:
   header:
     home: Home
     audited_entities: entidades auditadas
-  tableHeaders:
+  table_headers:
     entity: Entidad
     table: Tabla
     activity: Actividad
-  auditDetails:
+  audit_details:
     view_audit: Ver audit
     most_recent:  (el más reciente primero)
     entry_title: Ver todas las operaciones dentro de esta transacción

--- a/src/DoctrineAuditBundle/translations/messages.fr.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.fr.yaml
@@ -2,11 +2,11 @@ audit:
   header:
     home: Home
     audited_entities: entités auditées
-  tableHeaders:
+  table_headers:
     entity: Entité
     table: Table
     activity: Activité
-  auditDetails:
+  audit_details:
     view_audit: Afficher les audits
     most_recent: (le plus récent en premier)
     entry_title: Afficher toutes les opérations de cette transaction

--- a/src/DoctrineAuditBundle/translations/messages.fr.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.fr.yaml
@@ -1,0 +1,18 @@
+home: Home
+audited_entities: entités auditées
+entity: Entité
+table: Table
+activity: Activité
+view_audit: Afficher les audits
+most_recent: (le plus récent en premier)
+entry_title: afficher toutes les opérations de cette transaction
+property: Propriété
+old_value: ancienne valeur
+new_value: Nouvelle valeur
+transaction: Transaction
+entity_per_entity: (entité par entité)
+first: Premier
+previous: Précédent
+last: Dernier
+next: Suivant
+curreent:  courant

--- a/src/DoctrineAuditBundle/translations/messages.fr.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.fr.yaml
@@ -1,18 +1,23 @@
-home: Home
-audited_entities: entités auditées
-entity: Entité
-table: Table
-activity: Activité
-view_audit: Afficher les audits
-most_recent: (le plus récent en premier)
-entry_title: afficher toutes les opérations de cette transaction
-property: Propriété
-old_value: ancienne valeur
-new_value: Nouvelle valeur
-transaction: Transaction
-entity_per_entity: (entité par entité)
-first: Premier
-previous: Précédent
-last: Dernier
-next: Suivant
-curreent:  courant
+audit:
+  header:
+    home: Home
+    audited_entities: entités auditées
+  tableHeaders:
+    entity: Entité
+    table: Table
+    activity: Activité
+  auditDetails:
+    view_audit: Afficher les audits
+    most_recent: (le plus récent en premier)
+    entry_title: Afficher toutes les opérations de cette transaction
+    property: Propriété
+    old_value: Ancienne valeur
+    new_value: Nouvelle valeur
+    transaction: Transaction
+    entity_per_entity: (entité par entité)
+  pager:
+    first: Premier
+    previous: Précédent
+    last: Dernier
+    next: Suivant
+    current:  courant

--- a/src/DoctrineAuditBundle/translations/messages.it.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.it.yaml
@@ -1,0 +1,18 @@
+home: Home
+audited_entities: entità attualmente controllate
+entity: Entità
+table: Tabella
+activity: Attività
+view_audit: Visualizza audit
+most_recent: (la più recente per prima)
+entry_title: Visualizza tutte le operazioni per una transazione
+property: Proprietà
+old_value: Vecchio valore
+new_value: Nuovo valore
+transaction: Transazione
+entity_per_entity: (entità per entità)
+first: Primo
+previous: Precedente
+last: Ultimo
+next: Prossimo
+curreent:  attuale

--- a/src/DoctrineAuditBundle/translations/messages.it.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.it.yaml
@@ -1,18 +1,23 @@
-home: Home
-audited_entities: entità attualmente controllate
-entity: Entità
-table: Tabella
-activity: Attività
-view_audit: Visualizza audit
-most_recent: (la più recente per prima)
-entry_title: Visualizza tutte le operazioni per una transazione
-property: Proprietà
-old_value: Vecchio valore
-new_value: Nuovo valore
-transaction: Transazione
-entity_per_entity: (entità per entità)
-first: Primo
-previous: Precedente
-last: Ultimo
-next: Prossimo
-curreent:  attuale
+audit:
+  header:
+    home: Home
+    audited_entities: entità attualmente controllate
+  tableHeaders:
+    entity: Entità
+    table: Tabella
+    activity: Attività
+  auditDetails:
+    view_audit: Visualizza audit
+    most_recent: (la più recente per prima)
+    entry_title: Visualizza tutte le operazioni per una transazione
+    property: Proprietà
+    old_value: Vecchio valore
+    new_value: Nuovo valore
+    transaction: Transazione
+    entity_per_entity: (entità per entità)
+  pager:
+    first: Primo
+    previous: Precedente
+    last: Ultimo
+    next: Prossimo
+    current:  attuale

--- a/src/DoctrineAuditBundle/translations/messages.it.yaml
+++ b/src/DoctrineAuditBundle/translations/messages.it.yaml
@@ -2,11 +2,11 @@ audit:
   header:
     home: Home
     audited_entities: entità attualmente controllate
-  tableHeaders:
+  table_headers:
     entity: Entità
     table: Tabella
     activity: Attività
-  auditDetails:
+  audit_details:
     view_audit: Visualizza audit
     most_recent: (la più recente per prima)
     entry_title: Visualizza tutte le operazioni per una transazione


### PR DESCRIPTION
Related to #126 
Implemented symfony/translations
added 5 languages [english, italian, french, spanish, german]
- Italian has been traslated by me
- For french, spanish, german I used Google Translate