### PR TITLE
added flag parameter for enabling AuditController

### DIFF
--- a/src/DoctrineAuditBundle/AuditConfiguration.php
+++ b/src/DoctrineAuditBundle/AuditConfiguration.php
@@ -54,6 +54,11 @@ class AuditConfiguration
     private $enabled = true;
 
     /**
+     * @var bool
+     */
+    private $enabledViewer = true;
+
+    /**
      * @var FirewallMap
      */
     private $firewallMap;
@@ -117,6 +122,7 @@ class AuditConfiguration
         $this->is_pre43_dispatcher = 2 === \count($p) && 'event' !== $p[0]->name;
 
         $this->enabled = $config['enabled'];
+        $this->enabledViewer = $config['enabled_viewer'];
         $this->tablePrefix = $config['table_prefix'];
         $this->tableSuffix = $config['table_suffix'];
         $this->timezone = $config['timezone'];
@@ -181,6 +187,40 @@ class AuditConfiguration
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    /**
+     * enable audit Controller and its routing.
+     *
+     * @return $this
+     */
+    public function enableViewer(): self
+    {
+        $this->enabledViewer = true;
+
+        return $this;
+    }
+
+    /**
+     * disable audit Controller and its routing.
+     *
+     * @return $this
+     */
+    public function disableViewer(): self
+    {
+        $this->enabledViewer = false;
+
+        return $this;
+    }
+
+    /**
+     * Get enabled flag.
+     *
+     * @return bool
+     */
+    public function isEnabledViewer(): bool
+    {
+        return $this->enabledViewer;
     }
 
     /**

--- a/src/DoctrineAuditBundle/DHDoctrineAuditBundle.php
+++ b/src/DoctrineAuditBundle/DHDoctrineAuditBundle.php
@@ -2,6 +2,7 @@
 
 namespace DH\DoctrineAuditBundle;
 
+use DH\DoctrineAuditBundle\DependencyInjection\Compiler\DisableAuditViewerPass;
 use DH\DoctrineAuditBundle\DependencyInjection\Compiler\StorageConfigurationCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -12,6 +13,7 @@ class DHDoctrineAuditBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new DisableAuditViewerPass());
         $container->addCompilerPass(new StorageConfigurationCompilerPass());
     }
 }

--- a/src/DoctrineAuditBundle/DependencyInjection/Compiler/DisableAuditViewerPass.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Compiler/DisableAuditViewerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\DoctrineAuditBundle\DependencyInjection\Compiler;
+
+use DH\DoctrineAuditBundle\Controller\AuditController;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DisableAuditViewerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('dh_doctrine_audit.configuration')) {
+            return;
+        }
+
+        $config = $container->getParameter('dh_doctrine_audit.configuration');
+        if (null === $config['enabled_viewer']) {
+            return;
+        }
+
+        if (false === $config['enabled_viewer']) {
+            $container->removeDefinition(AuditController::class);
+        }
+    }
+}

--- a/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
+++ b/src/DoctrineAuditBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultTrue()
                 ->end()
 
+                ->scalarNode('enabled_viewer')
+                    ->defaultTrue()
+                ->end()
+
                 ->scalarNode('storage_entity_manager')
                     ->cannotBeEmpty()
                     ->defaultNull()

--- a/src/DoctrineAuditBundle/Resources/config/routes.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/routes.yaml
@@ -1,0 +1,3 @@
+dh_doctrine_audit:
+    resource: "@DHDoctrineAuditBundle/Controller/"
+    type: audit_loader

--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -97,3 +97,9 @@ services:
     calls:
       - { method: setContainer, arguments: ['@service_container'] }
     tags: ['controller.service_arguments']
+
+  DH\DoctrineAuditBundle\Routing\DoctrineAuditRoutingLoader:
+    tags: [routing.loader]
+    calls:
+      - { method: setRoutingLoaderAnnotation, arguments: ['@routing.loader.annotation'] }
+      - { method: setConfiguration, arguments: ['%dh_doctrine_audit.configuration%'] }

--- a/src/DoctrineAuditBundle/Routing/DoctrineAuditRoutingLoader.php
+++ b/src/DoctrineAuditBundle/Routing/DoctrineAuditRoutingLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\DoctrineAuditBundle\Routing;
+
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Routing\RouteCollection;
+
+class DoctrineAuditRoutingLoader extends Loader implements LoaderInterface
+{
+    private $annotationLoader;
+
+    private $configuration;
+
+    public function load($resource, ?string $type = null): RouteCollection
+    {
+        $routeCollection = new RouteCollection();
+        if (true === $this->configuration['enabled_viewer']) {
+            $routeCollection = $this->annotationLoader->load('DH\DoctrineAuditBundle\Controller\AuditController');
+        }
+
+        return $routeCollection;
+    }
+
+    public function supports($resource, ?string $type = null): bool
+    {
+        return 'audit_loader' === $type;
+    }
+
+    public function setRoutingLoaderAnnotation(AnnotatedRouteControllerLoader $loader): void
+    {
+        $this->annotationLoader = $loader;
+    }
+
+    public function setConfiguration(iterable $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+}

--- a/tests/DoctrineAuditBundle/AuditConfigurationTest.php
+++ b/tests/DoctrineAuditBundle/AuditConfigurationTest.php
@@ -84,6 +84,29 @@ final class AuditConfigurationTest extends BaseTest
         self::assertFalse($configuration->isEnabled(), 'Disabled. Global enabled is set to false.');
     }
 
+    public function testEnabledViewerDefault(): void
+    {
+        $configuration = $this->getAuditConfiguration();
+
+        self::assertTrue($configuration->isEnabledViewer(), 'enableViewer enabled by default.');
+    }
+
+    public function testEnabledViewer(): void
+    {
+        $configuration = $this->getAuditConfiguration();
+        $configuration->enableViewer();
+
+        self::assertTrue($configuration->isEnabledViewer(), 'Enabled by default.');
+    }
+
+    public function testDisabledViewer(): void
+    {
+        $configuration = $this->getAuditConfiguration();
+        $configuration->disableViewer();
+
+        self::assertFalse($configuration->isEnabledViewer(), 'Disabled. Global enabledViewer enabled is set to false.');
+    }
+
     public function testGloballyIgnoredColumns(): void
     {
         $ignored = [
@@ -414,6 +437,7 @@ final class AuditConfigurationTest extends BaseTest
                 'ignored_columns' => [],
                 'entities' => [],
                 'enabled' => true,
+                'enabled_viewer' => true,
             ], $options),
             new TokenStorageUserProvider(new CoreSecurity($container)),
             new RequestStack(),

--- a/tests/DoctrineAuditBundle/BaseTest.php
+++ b/tests/DoctrineAuditBundle/BaseTest.php
@@ -198,6 +198,7 @@ abstract class BaseTest extends TestCase
         return new AuditConfiguration(
             array_merge([
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',

--- a/tests/DoctrineAuditBundle/CoreTest.php
+++ b/tests/DoctrineAuditBundle/CoreTest.php
@@ -251,6 +251,7 @@ abstract class CoreTest extends BaseTest
         return new AuditConfiguration(
             array_merge([
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',

--- a/tests/DoctrineAuditBundle/DependencyInjection/Compiler/DisableAuditControllerPassTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/Compiler/DisableAuditControllerPassTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\DoctrineAuditBundle\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DisableAuditControllerPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new DisableAuditViewerPass());
+    }
+}

--- a/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
@@ -69,6 +69,7 @@ final class DHDoctrineAuditExtensionTest extends AbstractExtensionTestCase
             'dh_doctrine_audit.configuration',
             [
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'storage_entity_manager' => null,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',

--- a/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
+++ b/tests/DoctrineAuditBundle/Helper/AuditHelperTest.php
@@ -190,6 +190,7 @@ final class AuditHelperTest extends CoreTest
         $configuration = new AuditConfiguration(
             [
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
@@ -254,6 +255,7 @@ final class AuditHelperTest extends CoreTest
         $configuration = new AuditConfiguration(
             [
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
@@ -379,6 +381,7 @@ final class AuditHelperTest extends CoreTest
         $configuration = new AuditConfiguration(
             [
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',
@@ -411,6 +414,7 @@ final class AuditHelperTest extends CoreTest
         $configuration = new AuditConfiguration(
             [
                 'enabled' => true,
+                'enabled_viewer' => true,
                 'table_prefix' => '',
                 'table_suffix' => '_audit',
                 'timezone' => 'UTC',

--- a/tests/DoctrineAuditBundle/Manager/AuditTransactionTest.php
+++ b/tests/DoctrineAuditBundle/Manager/AuditTransactionTest.php
@@ -53,6 +53,7 @@ final class AuditTransactionTest extends BaseTest
                 'ignored_columns' => [],
                 'entities' => [],
                 'enabled' => true,
+                'enabled_viewer' => true,
             ], $options),
             new TokenStorageUserProvider(new Security($container)),
             new RequestStack(),


### PR DESCRIPTION
@DamienHarper & @maxhelias Hi all, I implemented a solution to programmatically disable AuditController::class,
this way a new configuration parameter could be set to *false* and that controller and its routes won't be available.

The use case to cover is a use case in which the library is used to store informatin on the persistence layer but they will be available in a different way to the user, for example through API.
The controller routes won't be exposed to any environment.

The parameter is:
- ```enable_audit_controller```

and has been added to the Configuration.php file.

- default value is *true*

reference issue #153 