### PR TITLE
Cleanup command accepts an ISO 8601 date interval

### DIFF
--- a/src/DoctrineAuditBundle/Command/CleanAuditLogsCommand.php
+++ b/src/DoctrineAuditBundle/Command/CleanAuditLogsCommand.php
@@ -45,7 +45,7 @@ class CleanAuditLogsCommand extends Command implements ContainerAwareInterface
             ->setDescription('Cleans audit tables')
             ->setName(self::$defaultName)
             ->addOption('no-confirm', null, InputOption::VALUE_NONE, 'No interaction mode')
-            ->addArgument('keep', InputArgument::OPTIONAL, 'Keep audits up to a date subtracted by a ISO 8601 date interval (e.g. P12M for 12 months or P7D for 7 days).', 'P12M')
+            ->addArgument('keep', InputArgument::OPTIONAL, 'Audits retention period (must be expressed as an ISO 8601 date interval, e.g. P12M to keep the last 12 months or P7D to keep the last 7 days).', 'P12M')
         ;
     }
 

--- a/src/DoctrineAuditBundle/Command/CleanAuditLogsCommand.php
+++ b/src/DoctrineAuditBundle/Command/CleanAuditLogsCommand.php
@@ -45,7 +45,7 @@ class CleanAuditLogsCommand extends Command implements ContainerAwareInterface
             ->setDescription('Cleans audit tables')
             ->setName(self::$defaultName)
             ->addOption('no-confirm', null, InputOption::VALUE_NONE, 'No interaction mode')
-            ->addArgument('keep', InputArgument::OPTIONAL, 'Keep last N months of audit.', '12')
+            ->addArgument('keep', InputArgument::OPTIONAL, 'Keep audits up to a date subtracted by a ISO 8601 date interval (e.g. P12M for 12 months or P7D for 7 days).', 'P12M')
         ;
     }
 
@@ -63,16 +63,37 @@ class CleanAuditLogsCommand extends Command implements ContainerAwareInterface
 
         $io = new SymfonyStyle($input, $output);
 
-        $keep = (int) $input->getArgument('keep');
-        if ($keep <= 0) {
-            $io->error("'keep' argument must be a positive number.");
-            $this->release();
+        if (is_numeric($input->getArgument('keep'))) {
+            $deprecationMessage = "Providing an integer value for the 'keep' argument is deprecated. Please use the ISO 8601 duration format (e.g. P12M).";
+            @\trigger_error($deprecationMessage, E_USER_DEPRECATED);
+            $io->writeln($deprecationMessage);
 
-            return 0;
+            $keep = (int) $input->getArgument('keep');
+
+            if ($keep <= 0) {
+                $io->error("'keep' argument must be a positive number.");
+                $this->release();
+    
+                return 0;
+            }
+
+            $until = new DateTime();
+            $until->modify('-'.$keep.' month');
+        } else {
+            $keep = strval($input->getArgument('keep'));
+
+            try {
+                $dateInterval = new \DateInterval($keep);
+            } catch (\Exception $e) {
+                $io->error(sprintf("'keep' argument must be a valid ISO 8601 date interval. '%s' given.", $keep));
+                $this->release();
+                
+                return 0;
+            }
+            
+            $until = new DateTime();
+            $until->sub($dateInterval);
         }
-
-        $until = new DateTime();
-        $until->modify('-'.$keep.' month');
 
         /**
          * @var AuditReader
@@ -87,8 +108,7 @@ class CleanAuditLogsCommand extends Command implements ContainerAwareInterface
         $entities = $reader->getEntities();
 
         $message = sprintf(
-            "You are about to clean audits older than %d months (up to <comment>%s</comment>): %d entities involved.\n Do you want to proceed?",
-            $keep,
+            "You are about to clean audits created before <comment>%s</comment>: %d entities involved.\n Do you want to proceed?",
             $until->format('Y-m-d'),
             \count($entities)
         );

--- a/tests/DoctrineAuditBundle/Command/CleanAuditLogsCommandTest.php
+++ b/tests/DoctrineAuditBundle/Command/CleanAuditLogsCommandTest.php
@@ -17,6 +17,21 @@ final class CleanAuditLogsCommandTest extends CoreTest
 {
     use LockableTrait;
 
+    public function testDeprecationOutput(): void
+    {
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--no-confirm' => true,
+            'keep' => 12,
+        ]);
+        $command->unlock();
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString("Providing an integer value for the 'keep' argument is deprecated. Please use the ISO 8601 duration format (e.g. P12M).", $output);
+    }
+
     public function testExecuteFailsWithKeepNegative(): void
     {
         $command = $this->createCommand();
@@ -50,9 +65,23 @@ final class CleanAuditLogsCommandTest extends CoreTest
         self::assertStringContainsString("'keep' argument must be a positive number.", $output);
     }
 
-    /**
-     * @depends testExecuteFailsWithKeepNull
-     */
+    public function testExecuteFailsWithKeepWrongFormat(): void
+    {
+        $keep = 'WRONG';
+
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--no-confirm' => true,
+            'keep' => $keep,
+        ]);
+        $command->unlock();
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString(sprintf("'keep' argument must be a valid ISO 8601 date interval. '%s' given.", $keep), $output);
+    }
+
     public function testExecute(): void
     {
         $command = $this->createCommand();


### PR DESCRIPTION
Added possibility to define an ISO 8601 date interval to be subtracted from current date in the clean audit logs command