### PR TITLE
Don't specify the doctrine connection in services.yml

### DIFF
--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -69,13 +69,13 @@ services:
     class: DH\DoctrineAuditBundle\Event\DoctrineSubscriber
     arguments: ["@dh_doctrine_audit.manager"]
     tags:
-      - { name: doctrine.event_subscriber, connection: default, priority: 1000000 }
+      - { name: doctrine.event_subscriber, priority: 1000000 }
 
   dh_doctrine_audit.event_subscriber.create_schema:
     class: DH\DoctrineAuditBundle\Event\CreateSchemaListener
     arguments: ["@dh_doctrine_audit.manager", "@dh_doctrine_audit.reader"]
     tags:
-      - { name: doctrine.event_subscriber, connection: default }
+      - { name: doctrine.event_subscriber }
 
   dh_doctrine_audit.command.clean:
     class: DH\DoctrineAuditBundle\Command\CleanAuditLogsCommand

--- a/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
+++ b/tests/DoctrineAuditBundle/DependencyInjection/DHDoctrineAuditExtensionTest.php
@@ -42,7 +42,7 @@ final class DHDoctrineAuditExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('dh_doctrine_audit.event_subscriber.doctrine', DoctrineSubscriber::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('dh_doctrine_audit.event_subscriber.doctrine', 0, 'dh_doctrine_audit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('dh_doctrine_audit.event_subscriber.doctrine', 'doctrine.event_subscriber', ['connection' => 'default', 'priority' => 1000000]);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('dh_doctrine_audit.event_subscriber.doctrine', 'doctrine.event_subscriber', ['priority' => 1000000]);
 
         $this->assertContainerBuilderHasService('dh_doctrine_audit.twig_extension', TwigExtension::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('dh_doctrine_audit.twig_extension', 0, 'doctrine');


### PR DESCRIPTION
Specifying the connection forces the user to override it in configuration if they don't use default as the name of their connection. Symfony already provides a configurable setting for the name of the connection as "doctrine.dbal.default_connection", and this will be used if one isn't specified in the service. This value defaults to default if not specified.