### PR TITLE
Fix service definition and restore functions.

### DIFF
--- a/src/DoctrineAuditBundle/Resources/config/services.yaml
+++ b/src/DoctrineAuditBundle/Resources/config/services.yaml
@@ -98,7 +98,7 @@ services:
       - { method: setContainer, arguments: ['@service_container'] }
     tags: ['controller.service_arguments']
 
-  DH\DoctrineAuditBundle\Routing\DoctrineAuditRoutingLoader:
+  DH\DoctrineAuditBundle\Routing\RoutingAnnotationLoader:
     tags: [routing.loader]
     calls:
       - { method: setRoutingLoaderAnnotation, arguments: ['@routing.loader.annotation'] }

--- a/src/DoctrineAuditBundle/Routing/RoutingAnnotationLoader.php
+++ b/src/DoctrineAuditBundle/Routing/RoutingAnnotationLoader.php
@@ -34,4 +34,14 @@ class RoutingAnnotationLoader extends Loader implements LoaderInterface
     {
         return 'audit_loader' === $type;
     }
+
+    public function setRoutingLoaderAnnotation(AnnotatedRouteControllerLoader $loader): void
+    {
+        $this->annotationLoader = $loader;
+    }
+
+    public function setConfiguration(array $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
 }


### PR DESCRIPTION
In 14db22f0, the DoctrineAuditRoutingLoader class was renamed but the service
definition was never updated. Additionally, some function calls, used in the
service definition were removed but the definition was never updated, causing
symfony to fail to intilize the service.