### PR TITLE
Check if  object is initialized before call initializeObject

### DIFF
--- a/src/DoctrineAuditBundle/Transaction/AuditTrait.php
+++ b/src/DoctrineAuditBundle/Transaction/AuditTrait.php
@@ -4,9 +4,11 @@ namespace DH\DoctrineAuditBundle\Transaction;
 
 use DH\DoctrineAuditBundle\Helper\DoctrineHelper;
 use DH\DoctrineAuditBundle\User\UserInterface;
+use Doctrine\Common\Persistence\Proxy;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\PersistentCollection;
 
 trait AuditTrait
 {
@@ -164,7 +166,15 @@ trait AuditTrait
             return null;
         }
 
-        $em->getUnitOfWork()->initializeObject($entity); // ensure that proxies are initialized
+        // ensure that proxies are initialized
+        if (
+            ($entity instanceof Proxy && !$entity->__isInitialized()) ||
+            ($entity instanceof PersistentCollection && !$entity->isInitialized())
+        ) {
+            $em->initializeObject($entity);
+        }
+
+
         /** @var ClassMetadata $meta */
         $meta = $em->getClassMetadata(DoctrineHelper::getRealClassName($entity));
         $pkName = $meta->getSingleIdentifierFieldName();


### PR DESCRIPTION
I've some problem with fixtures loading in a project after added this bundle.
Before this update, when I try to retrieve an entity by reference I've an empty Entity.

```php
$post1 = $referenceRepository->getReference('post_1');
$post1->getId();
```
`getId()` returns null

I've noticed that before to call `initializeObject($entity)` I've an object with all fields filled and after the call all fields are null.  With this update I've resolved the problem