### PR TITLE
Template static datetime fix

### DIFF
--- a/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
@@ -3,6 +3,7 @@
 
 <article class="timeline-entry">
     <div class="timeline-entry-inner">
+        <time class="timeline-time" datetime="{{ entry.created_at|date('Y-m-d H:i:s') }}">
         <time class="timeline-time" datetime="2014-01-10T03:45">
             <span>{{ entry.created_at|date('H:i:s') }}</span> <span>{{ entry.created_at|date('l d F Y') }}</span>
         </time>

--- a/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
+++ b/src/DoctrineAuditBundle/Resources/views/Audit/entry.html.twig
@@ -4,7 +4,6 @@
 <article class="timeline-entry">
     <div class="timeline-entry-inner">
         <time class="timeline-time" datetime="{{ entry.created_at|date('Y-m-d H:i:s') }}">
-        <time class="timeline-time" datetime="2014-01-10T03:45">
             <span>{{ entry.created_at|date('H:i:s') }}</span> <span>{{ entry.created_at|date('l d F Y') }}</span>
         </time>
 


### PR DESCRIPTION
Looks like template had a static date set by accident. Here's a fix.

I kept date formatting similar to what element contains.