### PR TITLE
fix Route import in ViewerController

### DIFF
--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -15,7 +15,7 @@ use DH\AuditorBundle\Tests\Controller\ViewerControllerTest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException as SymfonyAccessDeniedException;
 use Twig\Environment;
 


### PR DESCRIPTION
After upgrading to Symfony 7.4+ the auditor controller routes went missing. Found old annotation route import instead of attribute namespace in ViewerController.