### PR TITLE
feat: add support for twig/extra-bundle and twig/intl-extra ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "symfony/security-bundle": "^5.4|^6.4|^7.0|^8.0",
     "symfony/translation": "^5.4|^6.4|^7.0|^8.0",
     "symfony/twig-bundle": "^5.4|^6.4|^7.0|^8.0",
-    "twig/extra-bundle": "^3.3",
-    "twig/intl-extra": "^3.3"
+    "twig/extra-bundle": "^3.3|^4.0",
+    "twig/intl-extra": "^3.3|^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary

This PR adds support for Twig 4.x packages (`twig/extra-bundle` and `twig/intl-extra`), allowing the bundle to be used with Symfony 7.4+ projects.

## Changes

- Updated `twig/extra-bundle` constraint from `^3.3` to `^3.3|^4.0`
- Updated `twig/intl-extra` constraint from `^3.3` to `^3.3|^4.0`

## Context

Symfony 7.4 projects using Twig 4.x cannot currently install this bundle due to the version constraints on twig packages.

## Testing

The change is backward compatible - existing projects using Twig 3.x will continue to work.