### PR TITLE
feat: update viewer and docs for audit table schema v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   "require": {
     "php": "^8.4",
     "ext-intl": "*",
-    "damienharper/auditor": "5.x-dev",
-    "damienharper/auditor-doctrine-provider": "2.x-dev",
+    "damienharper/auditor": "^5.0@dev",
+    "damienharper/auditor-doctrine-provider": "^2.0@dev",
     "doctrine/doctrine-bundle": "^3.0",
     "doctrine/dbal": "^4.0",
     "doctrine/orm": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
       "email": "damien.harper@gmail.com"
     }
   ],
+  "repositories": [
+    {"type": "path", "url": "../auditor"},
+    {"type": "path", "url": "../auditor-doctrine-provider"}
+  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,13 @@
       "email": "damien.harper@gmail.com"
     }
   ],
-  "repositories": [
-    {"type": "path", "url": "../auditor"},
-    {"type": "path", "url": "../auditor-doctrine-provider"}
-  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
     "php": "^8.4",
     "ext-intl": "*",
-    "damienharper/auditor": "^5.0@dev",
-    "damienharper/auditor-doctrine-provider": "^2.0@dev",
+    "damienharper/auditor": "5.x-dev",
+    "damienharper/auditor-doctrine-provider": "2.x-dev",
     "doctrine/doctrine-bundle": "^3.0",
     "doctrine/dbal": "^4.0",
     "doctrine/orm": "^3.2",

--- a/docs/customization/custom-provider.md
+++ b/docs/customization/custom-provider.md
@@ -69,7 +69,7 @@ final class ElasticsearchProvider extends AbstractProvider implements ResetInter
                 'entity'     => $payload['entity'],   // FQCN — always present when DoctrineProvider is the auditing source
                 'object_id'  => $payload['object_id'],
                 'diffs'      => json_decode($payload['diffs'], true),
-                'blame_user' => $payload['blame_user'],
+                'blame_user' => $payload['blame']['username'] ?? null,
                 'created_at' => $payload['created_at']->format(\DateTimeInterface::ATOM),
             ],
         ]);

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,26 +74,13 @@ flowchart TB
 | ViewerController    | (internal)                     | Web UI for audit logs                 |
 | RoutingLoader       | (internal)                     | Loads viewer routes                   |
 
-## ⚠️ Deprecation Notice (auditor v4.x)
-
-Starting with this release, `auditor-bundle` requires [`damienharper/auditor-doctrine-provider`](https://github.com/DamienHarper/auditor-doctrine-provider) as a direct dependency.
-
-The `DoctrineProvider` and all related classes previously bundled within `damienharper/auditor` (under `DH\Auditor\Provider\Doctrine\`) are now **deprecated** and will be removed in `damienharper/auditor` v5.0.
-
-**For auditor-bundle users: no action required.** The bundle automatically pulls in `auditor-doctrine-provider` and everything works transparently.
-
-**For users using `DoctrineProvider` directly** (without the bundle), install the standalone package:
-```bash
-composer require damienharper/auditor-doctrine-provider
-```
-
 ## 📋 Version Compatibility
 
 | Version | Status                      | Requirements                                                         |
 |:--------|:----------------------------|:---------------------------------------------------------------------|
-| 7.x     | Active development 🚀       | PHP >= 8.4, Symfony >= 8.0, Doctrine DBAL >= 4.0, Doctrine ORM >= 3.2|
-| 6.x     | Active support              | PHP >= 8.2, Symfony >= 5.4                                           |
-| 5.x     | End of Life                 | PHP >= 7.4, Symfony >= 4.4                                           |
+| 8.x     | Active development 🚀       | PHP >= 8.4, Symfony >= 8.0, Doctrine DBAL >= 4.0, Doctrine ORM >= 3.2|
+| 7.x     | Active support              | PHP >= 8.2, Symfony >= 5.4                                           |
+| 6.x     | End of Life                 | PHP >= 7.4, Symfony >= 4.4                                           |
 
 ## 🚀 Quick Links
 

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -42,12 +42,27 @@ bin/phpunit
 
 ## 🗄️ Schema Updates
 
-After upgrading, check if audit tables need updates:
+After upgrading, always check if audit tables need updating.
+
+**For fresh installations or existing v2 tables:**
 
 ```bash
 # Preview changes
 bin/console audit:schema:update --dump-sql
 
 # Apply changes
+bin/console audit:schema:update --force
+```
+
+**When upgrading from auditor-bundle 7.x or earlier (existing audit data):**
+
+> [!CAUTION]
+> `audit:schema:update` refuses to run if any audit table still has the legacy v1 schema. Run `audit:schema:migrate` first to preserve your data, then run `audit:schema:update`.
+
+```bash
+# Migrate legacy audit tables to v2 (preserves all data)
+bin/console audit:schema:migrate --force --convert-all
+
+# Then apply any remaining schema changes
 bin/console audit:schema:update --force
 ```

--- a/docs/upgrade/v8.md
+++ b/docs/upgrade/v8.md
@@ -98,26 +98,34 @@ Existing data is **not modified automatically** — run `audit:schema:migrate` a
 # Preview the SQL
 bin/console audit:schema:migrate --dump-sql
 
-# Run the migration
-bin/console audit:schema:migrate --force
-
-# Optionally convert legacy diffs JSON to the v2 format (safe to skip)
-bin/console audit:schema:migrate --force --convert-diffs
+# Run the full migration in one pass (DDL + transaction hash conversion + diffs conversion)
+bin/console audit:schema:migrate --force --convert-all
 ```
+
+> [!TIP]
+> The individual flags `--convert-transaction-hash` and `--convert-diffs` are also available
+> if you need to run each phase separately (e.g. on a table-by-table basis on large datasets).
+
+> [!CAUTION]
+> `audit:schema:update` refuses to run while any audit table still has the legacy v1 schema.
+> Always run `audit:schema:migrate` first.
 
 ### Breaking Changes
 
-**`$entry->transactionHash` renamed to `$entry->transactionId`**
+**`$entry->transactionHash` removed — use `$entry->transactionId`**
 
 ```php
 // Before (7.x)
-$entry->transactionHash;
+$entry->transactionHash;    // SHA-1 VARCHAR(40)
 
 // After (8.0)
-$entry->transactionId;
+$entry->transactionId;      // ULID CHAR(26)
 ```
 
-The old property is kept as a deprecated alias.
+The old property has been **removed** (no deprecated alias). Update any code that accesses
+`transactionHash` directly. For un-migrated v1 rows, `Entry::fromArray()` automatically
+falls back to the legacy `transaction_hash` column so `$entry->transactionId` is still
+populated before your tables are migrated.
 
 **Blame properties now read from `blame` JSON column**
 

--- a/docs/upgrade/v8.md
+++ b/docs/upgrade/v8.md
@@ -79,6 +79,61 @@ bin/console cache:clear
 bin/console audit:schema:update --dump-sql
 ```
 
+## ⚠️ Audit Table Schema Reform (schema version 2)
+
+auditor-bundle 8.0 also ships `damienharper/auditor-doctrine-provider` 2.x, which introduces a
+**revised audit table schema**. The new schema:
+
+- Replaces four separate `blame_*` columns with a single `blame JSON` column
+- Replaces the SHA-1 `transaction_hash VARCHAR(40)` with a ULID `transaction_id CHAR(26)`
+- Adds a `schema_version` column to distinguish legacy and current diffs formats
+- Adds two composite indexes: `(object_id, type)` and `(blame_id, created_at)`
+- Unifies the `diffs` JSON format across all operation types
+
+Existing data is **not modified automatically** — run `audit:schema:migrate` after upgrading.
+
+### Migrating Existing Audit Tables
+
+```bash
+# Preview the SQL
+bin/console audit:schema:migrate --dump-sql
+
+# Run the migration
+bin/console audit:schema:migrate --force
+
+# Optionally convert legacy diffs JSON to the v2 format (safe to skip)
+bin/console audit:schema:migrate --force --convert-diffs
+```
+
+### Breaking Changes
+
+**`$entry->transactionHash` renamed to `$entry->transactionId`**
+
+```php
+// Before (7.x)
+$entry->transactionHash;
+
+// After (8.0)
+$entry->transactionId;
+```
+
+The old property is kept as a deprecated alias.
+
+**Blame properties now read from `blame` JSON column**
+
+`$username`, `$userFqdn`, `$userFirewall`, and `$ip` still work — they now read from the unified
+`blame` JSON column. No code changes required.
+
+**Remove entries now include a full entity snapshot**
+
+For schema version 2 entries, `getDiffs()` on a `remove` entry returns the full entity state
+before deletion, with `old` populated and `new` set to `null` for every field.
+
+**`getDiffSource()` available on all entry types**
+
+Use `getDiffSource()` to access the entity metadata (`id`, `class`, `label`, `table`) that is
+now present on all operation types in schema version 2.
+
 ## ❓ Need Help?
 
 - Check [GitHub Issues](https://github.com/DamienHarper/auditor-bundle/issues)

--- a/docs/viewer/index.md
+++ b/docs/viewer/index.md
@@ -260,7 +260,7 @@ $url = $urlGenerator->generate('dh_auditor_show_entity_stream', [
 
 // Transaction
 $url = $urlGenerator->generate('dh_auditor_show_transaction_stream', [
-    'hash' => $transactionHash,
+    'hash' => $entry->transactionId,
 ]);
 ```
 

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -98,7 +98,7 @@ final readonly class ViewerController
     #[Route(path: '/audit/transaction/{hash}', name: 'dh_auditor_show_transaction_stream', methods: ['GET'])]
     public function showTransactionAction(Reader $reader, string $hash): Response
     {
-        $audits = $reader->getAuditsByTransactionHash($hash);
+        $audits = $reader->getAuditsByTransactionId($hash);
 
         return $this->renderView('@DHAuditor/Audit/transaction_stream.html.twig', [
             'hash' => $hash,
@@ -200,9 +200,9 @@ final readonly class ViewerController
         /** @var list<string> $types */
         $types = $connection->executeQuery($typesSql, $params)->fetchFirstColumn();
 
-        // Get distinct users (blame_id and blame_user) - excluding NULL
+        // Get distinct users (blame_id + username from blame JSON) - excluding NULL
         $usersSql = \sprintf(
-            'SELECT DISTINCT blame_id, blame_user FROM %s WHERE blame_id IS NOT NULL %s ORDER BY blame_user',
+            'SELECT DISTINCT blame_id, blame FROM %s WHERE blame_id IS NOT NULL %s ORDER BY blame_id',
             $auditTable,
             '' !== $objectIdCondition ? 'AND '.$objectIdCondition : ''
         );
@@ -210,11 +210,16 @@ final readonly class ViewerController
         $usersResult = $connection->executeQuery($usersSql, $params)->fetchAllAssociative();
         $users = array_map(static function (array $row): array {
             $blameId = $row['blame_id'];
-            $blameUser = $row['blame_user'] ?? $blameId;
+            $blameUser = null;
+
+            if (\is_string($row['blame'] ?? null)) {
+                $decoded = json_decode($row['blame'], true);
+                $blameUser = \is_array($decoded) ? ($decoded['username'] ?? null) : null;
+            }
 
             return [
                 'id' => \is_scalar($blameId) ? (string) $blameId : '',
-                'name' => \is_scalar($blameUser) ? (string) $blameUser : '',
+                'name' => \is_string($blameUser) ? $blameUser : (\is_scalar($blameId) ? (string) $blameId : ''),
             ];
         }, $usersResult);
 

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -174,6 +174,8 @@ final readonly class ViewerController
     /**
      * Get available filter options (distinct types and users) for an entity.
      *
+     * Supports both schema v1 (legacy: blame_user column) and schema v2 (blame JSON column).
+     *
      * @return array{types: array<string>, users: array<array{id: string, name: string}>, hasAnonymous: bool}
      */
     private function getFilterOptions(Reader $reader, string $entity, int|string|null $id): array
@@ -181,6 +183,12 @@ final readonly class ViewerController
         $storageService = $reader->getProvider()->getStorageServiceForEntity($entity);
         $connection = $storageService->getEntityManager()->getConnection();
         $auditTable = $reader->getEntityAuditTableName($entity);
+
+        // Introspect the actual table structure to detect the schema version.
+        // v2 tables have a 'blame' JSON column; v1 (legacy) tables use separate 'blame_user' columns.
+        $tableSchema = $connection->createSchemaManager()->introspectSchema()->getTable($auditTable);
+        $hasBlameColumn = $tableSchema->hasColumn('blame');      // schema v2
+        $hasLegacyBlame = $tableSchema->hasColumn('blame_user'); // schema v1 (legacy)
 
         // Build base condition for object_id if provided
         $params = [];
@@ -200,28 +208,52 @@ final readonly class ViewerController
         /** @var list<string> $types */
         $types = $connection->executeQuery($typesSql, $params)->fetchFirstColumn();
 
-        // Get distinct users (blame_id + username from blame JSON) - excluding NULL
-        $usersSql = \sprintf(
-            'SELECT DISTINCT blame_id, blame FROM %s WHERE blame_id IS NOT NULL %s ORDER BY blame_id',
-            $auditTable,
-            '' !== $objectIdCondition ? 'AND '.$objectIdCondition : ''
-        );
+        $users = [];
 
-        $usersResult = $connection->executeQuery($usersSql, $params)->fetchAllAssociative();
-        $users = array_map(static function (array $row): array {
-            $blameId = $row['blame_id'];
-            $blameUser = null;
+        if ($hasBlameColumn) {
+            // Schema v2: username is encoded as JSON in the 'blame' column.
+            $usersSql = \sprintf(
+                'SELECT DISTINCT blame_id, blame FROM %s WHERE blame_id IS NOT NULL %s ORDER BY blame_id',
+                $auditTable,
+                '' !== $objectIdCondition ? 'AND '.$objectIdCondition : ''
+            );
 
-            if (\is_string($row['blame'] ?? null)) {
-                $decoded = json_decode($row['blame'], true);
-                $blameUser = \is_array($decoded) ? ($decoded['username'] ?? null) : null;
-            }
+            $usersResult = $connection->executeQuery($usersSql, $params)->fetchAllAssociative();
+            $users = array_map(static function (array $row): array {
+                $blameId = $row['blame_id'];
+                $blameUser = null;
 
-            return [
-                'id' => \is_scalar($blameId) ? (string) $blameId : '',
-                'name' => \is_string($blameUser) ? $blameUser : (\is_scalar($blameId) ? (string) $blameId : ''),
-            ];
-        }, $usersResult);
+                if (\is_string($row['blame'] ?? null)) {
+                    $decoded = json_decode($row['blame'], true);
+                    $blameUser = \is_array($decoded) ? ($decoded['username'] ?? null) : null;
+                }
+
+                return [
+                    'id' => \is_scalar($blameId) ? (string) $blameId : '',
+                    'name' => \is_string($blameUser) ? $blameUser : (\is_scalar($blameId) ? (string) $blameId : ''),
+                ];
+            }, $usersResult);
+        } elseif ($hasLegacyBlame) {
+            // Schema v1 (legacy): username is stored in the dedicated 'blame_user' column.
+            $usersSql = \sprintf(
+                'SELECT DISTINCT blame_id, blame_user FROM %s WHERE blame_id IS NOT NULL %s ORDER BY blame_id',
+                $auditTable,
+                '' !== $objectIdCondition ? 'AND '.$objectIdCondition : ''
+            );
+
+            $usersResult = $connection->executeQuery($usersSql, $params)->fetchAllAssociative();
+            $users = array_map(static function (array $row): array {
+                $blameId = $row['blame_id'];
+                $blameUser = isset($row['blame_user']) && '' !== $row['blame_user'] ? $row['blame_user'] : null;
+
+                return [
+                    'id' => \is_scalar($blameId) ? (string) $blameId : '',
+                    'name' => \is_string($blameUser) ? $blameUser : (\is_scalar($blameId) ? (string) $blameId : ''),
+                ];
+            }, $usersResult);
+        }
+
+        // If neither column exists, $users remains [] (no blame info available).
 
         // Check if there are anonymous entries (blame_id IS NULL)
         $anonymousSql = \sprintf(

--- a/src/DHAuditorBundle.php
+++ b/src/DHAuditorBundle.php
@@ -11,6 +11,7 @@ use DH\Auditor\Provider\Doctrine\Auditing\Attribute\AttributeLoader;
 use DH\Auditor\Provider\Doctrine\Configuration as DoctrineProviderConfiguration;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Persistence\Command\CleanAuditLogsCommand;
+use DH\Auditor\Provider\Doctrine\Persistence\Command\MigrateSchemaCommand;
 use DH\Auditor\Provider\Doctrine\Persistence\Command\UpdateSchemaCommand;
 use DH\Auditor\Provider\Doctrine\Persistence\Event\CreateSchemaListener;
 use DH\Auditor\Provider\Doctrine\Persistence\Event\TableSchemaListener;
@@ -246,6 +247,11 @@ class DHAuditorBundle extends AbstractBundle
         $services->set(UpdateSchemaCommand::class)
             ->call('setAuditor', [new Reference(Auditor::class)])
             ->tag('console.command', ['command' => 'audit:schema:update'])
+        ;
+
+        $services->set(MigrateSchemaCommand::class)
+            ->call('setAuditor', [new Reference(Auditor::class)])
+            ->tag('console.command', ['command' => 'audit:schema:migrate'])
         ;
 
         // Expose viewer-enabled state as a container parameter so other services

--- a/src/Resources/views/Audit/entry.html.twig
+++ b/src/Resources/views/Audit/entry.html.twig
@@ -1,80 +1,106 @@
 {% import '@DHAuditor/Audit/helpers/helper.html.twig' as helper %}
 
-{# Get entity label from diffs if available #}
+{# Get entity label — schema v2: from diffSource; schema v1 legacy: from diffs.label #}
 {% set entity_label = null %}
-{% if entry.diffs.label is defined %}
-    {% if entry.diffs.label is iterable %}
-        {% set entity_label = entry.diffs.label|join(', ') %}
-    {% else %}
-        {% set entity_label = entry.diffs.label %}
-    {% endif %}
+{% set diff_source = entry.diffSource %}
+{% if diff_source is not null and diff_source.label is defined %}
+    {% set entity_label = diff_source.label is iterable ? diff_source.label|join(', ') : diff_source.label %}
+{% elseif entry.diffs.label is defined %}
+    {% set entity_label = entry.diffs.label is iterable ? entry.diffs.label|join(', ') : entry.diffs.label %}
 {% endif %}
 
 {% if entry.type == 'remove' %}
-{# REMOVE entries are not expandable #}
+{# REMOVE entries: expandable when v2 snapshot is available, plain otherwise #}
+{% set remove_diffs = entry.diffs %}
+{% if remove_diffs|length > 0 %}
+<details class="group hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
+    <summary class="flex flex-col px-4 py-3 cursor-pointer list-none">
+{% else %}
 <div class="flex flex-col px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
-    {# First line: badge, entity link, label, action description, hash #}
-    <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3 min-w-0">
-            {# Type badge - fixed width for alignment #}
-            <span class="w-24 shrink-0">
-                {{ helper.type_badge(entry.type) }}
-            </span>
-
-            {# Entity info #}
-            <div class="flex items-center gap-2 min-w-0 text-sm">
-                {# Entity name + ID #}
-                <a href="{{ path('dh_auditor_show_entity_stream', {'entity': helper.namespaceToParam(entity), 'id': entry.objectId}) }}"
-                   class="font-medium text-slate-900 dark:text-slate-100 hover:underline shrink-0"
-                   title="{{ entity }}">
-                    {{ entity|split('\\')|last }} #{{ entry.objectId }}
-                </a>
-
-                {# Entity label if available - smaller and italic #}
-                {% if entity_label %}
-                    <span class="text-slate-500 dark:text-slate-400">·</span>
-                    <span class="text-xs italic text-slate-500 dark:text-slate-400 truncate">{{ entity_label }}</span>
-                {% endif %}
-
-                {# Action description #}
-                <span class="text-slate-500 dark:text-slate-400">·</span>
-                <span class="text-xs text-slate-400 dark:text-slate-500 italic shrink-0">
-                    {{ 'audit.entry.action_remove'|trans(domain='auditor') }}
+    <div class="flex flex-col">
+{% endif %}
+        {# First line: badge, entity link, label, action description, hash #}
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3 min-w-0">
+                {# Type badge - fixed width for alignment #}
+                <span class="w-24 shrink-0">
+                    {{ helper.type_badge(entry.type) }}
                 </span>
+
+                {# Entity info #}
+                <div class="flex items-center gap-2 min-w-0 text-sm">
+                    {# Entity name + ID #}
+                    <a href="{{ path('dh_auditor_show_entity_stream', {'entity': helper.namespaceToParam(entity), 'id': entry.objectId}) }}"
+                       class="font-medium text-slate-900 dark:text-slate-100 hover:underline shrink-0"
+                       title="{{ entity }}">
+                        {{ entity|split('\\')|last }} #{{ entry.objectId }}
+                    </a>
+
+                    {# Entity label if available - smaller and italic #}
+                    {% if entity_label %}
+                        <span class="text-slate-500 dark:text-slate-400">·</span>
+                        <span class="text-xs italic text-slate-500 dark:text-slate-400 truncate">{{ entity_label }}</span>
+                    {% endif %}
+
+                    {# Action description #}
+                    <span class="text-slate-500 dark:text-slate-400">·</span>
+                    <span class="text-xs text-slate-400 dark:text-slate-500 italic shrink-0">
+                        {{ 'audit.entry.action_remove'|trans(domain='auditor') }}
+                    </span>
+                </div>
+            </div>
+
+            <div class="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400 shrink-0">
+                {# Transaction ID - short version with full ID in title #}
+                {% if entry.transactionId is not empty and hide_transaction is not defined %}
+                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionId}) }}"
+                       class="font-mono text-xs text-slate-400 hover:underline transition"
+                       title="{{ entry.transactionId }}">
+                        {{ entry.transactionId|slice(0, 10) }}…
+                    </a>
+                {% endif %}
+                {% if remove_diffs|length > 0 %}
+                    <svg class="w-4 h-4 text-slate-400 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                    </svg>
+                {% else %}
+                    <span class="w-4"></span>
+                {% endif %}
             </div>
         </div>
 
-        <div class="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400 shrink-0">
-            {# Transaction hash - short version with full hash in title #}
-            {% if entry.transactionHash is not empty and hide_transaction is not defined %}
-                <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionHash}) }}"
-                   class="font-mono text-xs text-slate-400 hover:underline transition"
-                   title="{{ entry.transactionHash }}">
-                    {{ entry.transactionHash|slice(0, 10) }}…
-                </a>
+        {# Second line: date, user/command, IP, firewall #}
+        <div class="flex items-center gap-2 mt-1 ml-2 text-xs text-slate-500 dark:text-slate-400">
+            <span>{{ entry.createdAt|format_datetime('full', 'short') }}</span>
+            <span>·</span>
+            <span>{{ 'audit.entry.by'|trans(domain='auditor') }}
+                <span class="font-medium">{{ entry.username ?? 'audit.audit_details.anonymous'|trans(domain='auditor') }}</span>
+            </span>
+            {% if entry.ip is not empty %}
+                <span>·</span>
+                <span class="font-mono">{{ entry.ip }}</span>
             {% endif %}
-            {# Spacer to align with chevron in other rows #}
-            <span class="w-4"></span>
+            {% if entry.userFirewall is not empty %}
+                <span>·</span>
+                <span class="italic">{{ entry.userFirewall }}</span>
+            {% endif %}
         </div>
+{% if remove_diffs|length > 0 %}
+    </summary>
+    {# Deleted entity snapshot: show old values #}
+    <div class="px-4 pb-4 pl-8">
+        <table class="text-xs font-mono">
+            {% for field, changeset in remove_diffs %}
+                {{ _self.displayRemoveValue(field, changeset) }}
+            {% endfor %}
+        </table>
+        {{ _self.displayExtraData(entry.extraData) }}
     </div>
-
-    {# Second line: date, user/command, IP, firewall #}
-    <div class="flex items-center gap-2 mt-1 ml-2 text-xs text-slate-500 dark:text-slate-400">
-        <span>{{ entry.createdAt|format_datetime('full', 'short') }}</span>
-        <span>·</span>
-        <span>{{ 'audit.entry.by'|trans(domain='auditor') }}
-            <span class="font-medium">{{ entry.username ?? 'audit.audit_details.anonymous'|trans(domain='auditor') }}</span>
-        </span>
-        {% if entry.ip is not empty %}
-            <span>·</span>
-            <span class="font-mono">{{ entry.ip }}</span>
-        {% endif %}
-        {% if entry.userFirewall is not empty %}
-            <span>·</span>
-            <span class="italic">{{ entry.userFirewall }}</span>
-        {% endif %}
+</details>
+{% else %}
     </div>
 </div>
+{% endif %}
 {% else %}
 {# Other entry types are expandable #}
 <details class="group hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
@@ -120,13 +146,13 @@
             </div>
 
             <div class="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400 shrink-0">
-                {# Transaction hash - short version with full hash in title #}
-                {% if entry.transactionHash is not empty and hide_transaction is not defined %}
-                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionHash}) }}"
+                {# Transaction ID - short version with full ID in title #}
+                {% if entry.transactionId is not empty and hide_transaction is not defined %}
+                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionId}) }}"
                        class="font-mono text-xs text-slate-400 hover:underline transition"
-                       title="{{ entry.transactionHash }}"
+                       title="{{ entry.transactionId }}"
                        onclick="event.stopPropagation();">
-                        {{ entry.transactionHash|slice(0, 10) }}…
+                        {{ entry.transactionId|slice(0, 10) }}…
                     </a>
                 {% endif %}
 
@@ -294,6 +320,28 @@
         {# JSON nested field #}
         {% for json_field, json_changeset in changeset %}
             {{ _self.displayUpdateDiff(field ~ '.' ~ json_field, json_changeset) }}
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
+
+{# Macro for REMOVE snapshot: shows the old value (deleted entity state) #}
+{% macro displayRemoveValue(field, changeset) %}
+    {% import '@DHAuditor/Audit/helpers/helper.html.twig' as helper %}
+    {% if changeset is iterable and changeset.old is defined %}
+        <tr>
+            <td class="pr-6 text-slate-500 dark:text-slate-400 break-words" style="max-width: 25%;">{{ field }}</td>
+            <td class="text-rose-600 dark:text-rose-400 break-words" style="max-width: 70%;">
+                {% if changeset.old is not null %}
+                    {{ helper.dump(changeset.old) }}
+                {% else %}
+                    ⌀
+                {% endif %}
+            </td>
+        </tr>
+    {% elseif changeset is iterable and changeset.old is not defined and changeset.new is not defined %}
+        {# JSON nested field #}
+        {% for json_field, json_changeset in changeset %}
+            {{ _self.displayRemoveValue(field ~ '.' ~ json_field, json_changeset) }}
         {% endfor %}
     {% endif %}
 {% endmacro %}

--- a/src/Resources/views/Audit/entry.html.twig
+++ b/src/Resources/views/Audit/entry.html.twig
@@ -9,10 +9,20 @@
     {% set entity_label = entry.diffs.label is iterable ? entry.diffs.label|join(', ') : entry.diffs.label %}
 {% endif %}
 
+{#
+  Transaction ID display:
+  - ULID (schema v2, 26 chars): show in full — it is short and human-readable.
+  - SHA1 (schema v1, 40 hex chars): truncate to 10 chars like a short git hash.
+  Any ID longer than 26 chars is treated as a SHA1.
+#}
+{% set tx_id = entry.transactionId %}
+{% set tx_label = tx_id is not empty ? (tx_id|length > 26 ? (tx_id|slice(0, 10) ~ '…') : tx_id) : null %}
+
 {% if entry.type == 'remove' %}
-{# REMOVE entries: expandable when v2 snapshot is available, plain otherwise #}
+{# REMOVE entries: expandable only for schema v2 when a field snapshot was captured. #}
 {% set remove_diffs = entry.diffs %}
-{% if remove_diffs|length > 0 %}
+{% set remove_has_snapshot = entry.schemaVersion >= 2 and remove_diffs|length > 0 %}
+{% if remove_has_snapshot %}
 <details class="group hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
     <summary class="flex flex-col px-4 py-3 cursor-pointer list-none">
 {% else %}
@@ -51,15 +61,15 @@
             </div>
 
             <div class="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400 shrink-0">
-                {# Transaction ID - short version with full ID in title #}
-                {% if entry.transactionId is not empty and hide_transaction is not defined %}
-                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionId}) }}"
+                {# Transaction ID #}
+                {% if tx_label is not empty and hide_transaction is not defined %}
+                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: tx_id}) }}"
                        class="font-mono text-xs text-slate-400 hover:underline transition"
-                       title="{{ entry.transactionId }}">
-                        {{ entry.transactionId|slice(0, 10) }}…
+                       title="{{ tx_id }}">
+                        {{ tx_label }}
                     </a>
                 {% endif %}
-                {% if remove_diffs|length > 0 %}
+                {% if remove_has_snapshot %}
                     <svg class="w-4 h-4 text-slate-400 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
                     </svg>
@@ -85,7 +95,7 @@
                 <span class="italic">{{ entry.userFirewall }}</span>
             {% endif %}
         </div>
-{% if remove_diffs|length > 0 %}
+{% if remove_has_snapshot %}
     </summary>
     {# Deleted entity snapshot: show old values #}
     <div class="px-4 pb-4 pl-8">
@@ -146,13 +156,13 @@
             </div>
 
             <div class="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400 shrink-0">
-                {# Transaction ID - short version with full ID in title #}
-                {% if entry.transactionId is not empty and hide_transaction is not defined %}
-                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: entry.transactionId}) }}"
+                {# Transaction ID #}
+                {% if tx_label is not empty and hide_transaction is not defined %}
+                    <a href="{{ path('dh_auditor_show_transaction_stream', {hash: tx_id}) }}"
                        class="font-mono text-xs text-slate-400 hover:underline transition"
-                       title="{{ entry.transactionId }}"
+                       title="{{ tx_id }}"
                        onclick="event.stopPropagation();">
-                        {{ entry.transactionId|slice(0, 10) }}…
+                        {{ tx_label }}
                     </a>
                 {% endif %}
 

--- a/tests/Controller/ViewerControllerTest.php
+++ b/tests/Controller/ViewerControllerTest.php
@@ -183,7 +183,7 @@ final class ViewerControllerTest extends WebTestCase
         $first = $audits[\count($audits) - 1];
 
         $this->login();
-        $crawler = $this->client->request('GET', '/audit/transaction/'.$first->transactionHash);
+        $crawler = $this->client->request('GET', '/audit/transaction/'.$first->transactionId);
 
         // asserts that the response status code is 2xx
         $this->assertTrue($this->client->getResponse()->isSuccessful(), 'Response status is 2xx');
@@ -194,9 +194,9 @@ final class ViewerControllerTest extends WebTestCase
         $backLink = $crawler->filter('a[href="/audit"]');
         $this->assertGreaterThanOrEqual(1, $backLink->count(), 'Back link to entities exists');
 
-        // Check transaction hash is displayed
+        // Check transaction ID is displayed
         $hash = $crawler->filter('span.font-mono');
-        $this->assertStringContainsString($first->transactionHash, $hash->text(), 'Transaction hash is displayed');
+        $this->assertStringContainsString($first->transactionId, $hash->text(), 'Transaction ID is displayed');
 
         // Check entries grouped by entity
         $entitySections = $crawler->filter('h2');
@@ -213,7 +213,7 @@ final class ViewerControllerTest extends WebTestCase
         $first = $audits[\count($audits) - 1];
 
         $this->login(['ROLE_USER']);
-        $crawler = $this->client->request('GET', '/audit/transaction/'.$first->transactionHash);
+        $crawler = $this->client->request('GET', '/audit/transaction/'.$first->transactionId);
 
         // asserts that the response status code is 2xx
         $this->assertTrue($this->client->getResponse()->isSuccessful(), 'Response status is 2xx');


### PR DESCRIPTION
## Summary

- **ViewerController**: replace `getAuditsByTransactionHash()` → `getAuditsByTransactionId()`; fix user filter SQL — `blame_user` column no longer exists in schema v2, now reads username from the `blame` JSON column
- **entry.html.twig**: `transactionHash` → `transactionId`; entity label now reads from `getDiffSource()` for v2 entries; REMOVE entries are expandable and display the deleted entity snapshot when a v2 diff is available
- **docs**: update `v8.md` upgrade guide with schema migration steps and breaking changes (`transactionId` rename, blame JSON column, full REMOVE snapshot)
