### PR TITLE
feat: introduce ConsoleUserProviderInterface to allow decoration

### DIFF
--- a/src/Event/ConsoleEventSubscriber.php
+++ b/src/Event/ConsoleEventSubscriber.php
@@ -6,7 +6,7 @@ namespace DH\AuditorBundle\Event;
 
 use DH\Auditor\Configuration;
 use DH\Auditor\User\UserProviderInterface;
-use DH\AuditorBundle\User\ConsoleUserProvider;
+use DH\AuditorBundle\User\ConsoleUserProviderInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 final readonly class ConsoleEventSubscriber
 {
     public function __construct(
-        private ConsoleUserProvider $consoleUserProvider,
+        private ConsoleUserProviderInterface $consoleUserProvider,
         private Configuration $configuration,
         private UserProviderInterface $provider,
     ) {}

--- a/src/User/ConsoleUserProvider.php
+++ b/src/User/ConsoleUserProvider.php
@@ -6,10 +6,9 @@ namespace DH\AuditorBundle\User;
 
 use DH\Auditor\User\User;
 use DH\Auditor\User\UserInterface;
-use DH\Auditor\User\UserProviderInterface;
 use Symfony\Component\Console\Command\Command;
 
-final class ConsoleUserProvider implements UserProviderInterface
+final class ConsoleUserProvider implements ConsoleUserProviderInterface
 {
     private ?string $currentCommand = null;
 

--- a/src/User/ConsoleUserProviderInterface.php
+++ b/src/User/ConsoleUserProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\AuditorBundle\User;
+
+use DH\Auditor\User\UserProviderInterface;
+use Symfony\Component\Console\Command\Command;
+
+interface ConsoleUserProviderInterface extends UserProviderInterface
+{
+    public function setCurrentCommand(?Command $command): void;
+}


### PR DESCRIPTION
## Summary

- Introduces `ConsoleUserProviderInterface` extending `UserProviderInterface` and declaring `setCurrentCommand()`
- `ConsoleUserProvider` now implements `ConsoleUserProviderInterface` instead of `UserProviderInterface` directly
- `ConsoleEventSubscriber` is now type-hinted on `ConsoleUserProviderInterface` instead of the concrete `ConsoleUserProvider`, making it fully decoratable via Symfony's DI container

Closes #614