### PR TITLE
feat: add streaming audit export HTTP endpoint

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\AuditorBundle\Controller;
+
+use DH\Auditor\Exception\InvalidArgumentException;
+use DH\Auditor\Model\Entry;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\DateRangeFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Query;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
+use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
+use DH\AuditorBundle\Helper\UrlHelper;
+use DH\AuditorBundle\Tests\Controller\ExportControllerTest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @see ExportControllerTest
+ */
+#[AsController]
+final readonly class ExportController
+{
+    private const array VALID_FORMATS = ['ndjson', 'json', 'csv'];
+
+    #[Route(path: '/audit/export', name: 'dh_auditor_export', methods: ['GET'])]
+    public function exportAction(Request $request, Reader $reader): StreamedResponse
+    {
+        /** @var string $format */
+        $format = $request->query->getString('format', 'ndjson');
+
+        if (!\in_array($format, self::VALID_FORMATS, true)) {
+            throw new BadRequestHttpException(\sprintf("Invalid format '%s'. Allowed formats: %s.", $format, implode(', ', self::VALID_FORMATS)));
+        }
+
+        $entityParam = $request->query->getString('entity', '');
+        $entity = '' !== $entityParam ? UrlHelper::paramToNamespace($entityParam) : null;
+
+        $fromParam = $request->query->getString('from', '');
+        $toParam = $request->query->getString('to', '');
+
+        $from = '' !== $fromParam ? $this->parseDate($fromParam, 'from') : null;
+        $to = '' !== $toParam ? $this->parseDate($toParam, 'to') : null;
+
+        $id = $request->query->getString('id', '');
+        $blameId = $request->query->getString('blame_id', '');
+        $anonymize = $request->query->getBoolean('anonymize', false);
+
+        $entities = $this->resolveEntities($entity, $reader);
+
+        $contentType = match ($format) {
+            'ndjson' => 'application/x-ndjson',
+            'json' => 'application/json',
+            'csv' => 'text/csv; charset=UTF-8',
+        };
+
+        $filenameBase = null !== $entity
+            ? str_replace('\\', '_', $entity)
+            : 'all';
+
+        $extension = 'ndjson' === $format ? 'ndjson' : $format;
+        $filename = \sprintf('audit-export-%s-%s.%s', $filenameBase, (new \DateTimeImmutable())->format('Ymd-His'), $extension);
+
+        $timezone = new \DateTimeZone($reader->getProvider()->getAuditor()->getConfiguration()->timezone);
+
+        return new StreamedResponse(
+            function () use ($reader, $entities, $id, $blameId, $from, $to, $format, $anonymize, $timezone): void {
+                $first = true;
+                $headerWritten = false;
+
+                if ('json' === $format) {
+                    echo '[';
+                }
+
+                foreach ($entities as $entityFqcn) {
+                    try {
+                        $query = $reader->createQuery($entityFqcn, ['page_size' => null]);
+                    } catch (InvalidArgumentException) {
+                        continue;
+                    }
+
+                    if ('' !== $id) {
+                        $query->addFilter(new SimpleFilter(Query::OBJECT_ID, $id));
+                    }
+
+                    if ('' !== $blameId) {
+                        $query->addFilter(new SimpleFilter(Query::USER_ID, $blameId));
+                    }
+
+                    if ($from instanceof \DateTimeImmutable || $to instanceof \DateTimeImmutable) {
+                        $query->addFilter(new DateRangeFilter(Query::CREATED_AT, $from, $to));
+                    }
+
+                    foreach ($query->iterate() as $row) {
+                        \assert(\is_string($row['created_at']));
+                        $row['created_at'] = new \DateTimeImmutable($row['created_at'], $timezone);
+
+                        if ($anonymize) {
+                            $row['blame_id'] = null;
+                            $row['blame'] = null;
+                            $row['blame_user'] = null;
+                            $row['blame_user_fqdn'] = null;
+                            $row['blame_user_firewall'] = null;
+                            $row['ip'] = null;
+                        }
+
+                        $data = Entry::fromArray($row)->toArray();
+
+                        match ($format) {
+                            'ndjson' => $this->echoNdjson($data),
+                            'json' => $this->echoJson($data, $first),
+                            'csv' => $this->echoCsv($data, $headerWritten),
+                        };
+                    }
+
+                    ob_flush();
+                    flush();
+                }
+
+                if ('json' === $format) {
+                    echo ']';
+                }
+            },
+            200,
+            [
+                'Content-Type' => $contentType,
+                'Content-Disposition' => \sprintf('attachment; filename="%s"', $filename),
+                'X-Accel-Buffering' => 'no',
+            ]
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveEntities(?string $entity, Reader $reader): array
+    {
+        if (null !== $entity) {
+            // Validate the entity is known and auditable by attempting createQuery().
+            try {
+                $reader->createQuery($entity, ['page_size' => 1]);
+            } catch (InvalidArgumentException) {
+                throw new NotFoundHttpException(\sprintf("Entity '%s' is not auditable.", $entity));
+            }
+
+            return [$entity];
+        }
+
+        $schemaManager = new SchemaManager($reader->getProvider());
+
+        /** @var array<string, array<string, string>> $repository */
+        $repository = $schemaManager->collectAuditableEntities();
+
+        $entities = [];
+
+        foreach ($repository as $classes) {
+            foreach ($classes as $fqcn => $table) {
+                $entities[] = $fqcn;
+            }
+        }
+
+        return $entities;
+    }
+
+    private function parseDate(string $value, string $param): \DateTimeImmutable
+    {
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Exception) {
+            throw new BadRequestHttpException(\sprintf("Invalid date for '%s': %s.", $param, $value));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function echoNdjson(array $data): void
+    {
+        echo json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE)."\n";
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function echoJson(array $data, bool &$first): void
+    {
+        if (!$first) {
+            echo ',';
+        }
+
+        echo json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        $first = false;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function echoCsv(array $data, bool &$headerWritten): void
+    {
+        if (!$headerWritten) {
+            echo $this->toCsvLine(array_keys($data));
+            $headerWritten = true;
+        }
+
+        echo $this->toCsvLine($this->flattenForCsv($data));
+    }
+
+    /**
+     * @param list<null|bool|float|int|string> $fields
+     */
+    private function toCsvLine(array $fields): string
+    {
+        $stream = fopen('php://temp', 'r+');
+        \assert(\is_resource($stream));
+        fputcsv($stream, $fields);
+        rewind($stream);
+        $line = stream_get_contents($stream);
+        fclose($stream);
+
+        return \is_string($line) ? $line : '';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<null|bool|float|int|string>
+     */
+    private function flattenForCsv(array $data): array
+    {
+        return array_values(array_map(
+            static fn (mixed $value): bool|float|int|string|null => \is_array($value)
+                ? json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE)
+                : (\is_scalar($value) || null === $value ? $value : null),
+            $data
+        ));
+    }
+}

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\AuditorBundle\Controller;
 
+use DH\Auditor\Attribute\Security;
 use DH\Auditor\Exception\InvalidArgumentException;
 use DH\Auditor\Model\Entry;
 use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\DateRangeFilter;
@@ -14,8 +15,10 @@ use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
 use DH\AuditorBundle\Helper\UrlHelper;
 use DH\AuditorBundle\Tests\Controller\ExportControllerTest;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -31,7 +34,6 @@ final readonly class ExportController
     #[Route(path: '/audit/export', name: 'dh_auditor_export', methods: ['GET'])]
     public function exportAction(Request $request, Reader $reader): StreamedResponse
     {
-        /** @var string $format */
         $format = $request->query->getString('format', 'ndjson');
 
         if (!\in_array($format, self::VALID_FORMATS, true)) {
@@ -63,8 +65,8 @@ final readonly class ExportController
             ? str_replace('\\', '_', $entity)
             : 'all';
 
-        $extension = 'ndjson' === $format ? 'ndjson' : $format;
-        $filename = \sprintf('audit-export-%s-%s.%s', $filenameBase, (new \DateTimeImmutable())->format('Ymd-His'), $extension);
+        $extension = $format;
+        $filename = \sprintf('audit-export-%s-%s.%s', $filenameBase, new \DateTimeImmutable()->format('Ymd-His'), $extension);
 
         $timezone = new \DateTimeZone($reader->getProvider()->getAuditor()->getConfiguration()->timezone);
 
@@ -116,17 +118,20 @@ final readonly class ExportController
                             'json' => $this->echoJson($data, $first),
                             'csv' => $this->echoCsv($data, $headerWritten),
                         };
-                    }
 
-                    ob_flush();
-                    flush();
+                        if (ob_get_level() > 0) {
+                            ob_flush();
+                        }
+
+                        flush();
+                    }
                 }
 
                 if ('json' === $format) {
                     echo ']';
                 }
             },
-            200,
+            Response::HTTP_OK,
             [
                 'Content-Type' => $contentType,
                 'Content-Disposition' => \sprintf('attachment; filename="%s"', $filename),
@@ -140,7 +145,14 @@ final readonly class ExportController
      */
     private function resolveEntities(?string $entity, Reader $reader): array
     {
+        $roleChecker = $reader->getProvider()->getAuditor()->getConfiguration()->getRoleChecker();
+
         if (null !== $entity) {
+            // Check access before validating existence to avoid leaking entity names to unauthorized callers.
+            if (null !== $roleChecker && !(bool) $roleChecker($entity, Security::VIEW_SCOPE)) {
+                throw new AccessDeniedHttpException(\sprintf("Access denied to audit log for '%s'.", $entity));
+            }
+
             // Validate the entity is known and auditable by attempting createQuery().
             try {
                 $reader->createQuery($entity, ['page_size' => 1]);
@@ -160,7 +172,9 @@ final readonly class ExportController
 
         foreach ($repository as $classes) {
             foreach ($classes as $fqcn => $table) {
-                $entities[] = $fqcn;
+                if (null === $roleChecker || (bool) $roleChecker($fqcn, Security::VIEW_SCOPE)) {
+                    $entities[] = $fqcn;
+                }
             }
         }
 
@@ -216,13 +230,21 @@ final readonly class ExportController
     private function toCsvLine(array $fields): string
     {
         $stream = fopen('php://temp', 'r+');
-        \assert(\is_resource($stream));
-        fputcsv($stream, $fields);
+
+        if (!\is_resource($stream)) {
+            throw new \RuntimeException('Failed to open temporary stream for CSV generation.');
+        }
+
+        fputcsv($stream, $fields, escape: '\\');
         rewind($stream);
         $line = stream_get_contents($stream);
         fclose($stream);
 
-        return \is_string($line) ? $line : '';
+        if (false === $line) {
+            throw new \RuntimeException('Failed to read from temporary stream.');
+        }
+
+        return $line;
     }
 
     /**

--- a/src/DHAuditorBundle.php
+++ b/src/DHAuditorBundle.php
@@ -11,6 +11,7 @@ use DH\Auditor\Provider\Doctrine\Auditing\Attribute\AttributeLoader;
 use DH\Auditor\Provider\Doctrine\Configuration as DoctrineProviderConfiguration;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Persistence\Command\CleanAuditLogsCommand;
+use DH\Auditor\Provider\Doctrine\Persistence\Command\ExportAuditLogsCommand;
 use DH\Auditor\Provider\Doctrine\Persistence\Command\MigrateSchemaCommand;
 use DH\Auditor\Provider\Doctrine\Persistence\Command\UpdateSchemaCommand;
 use DH\Auditor\Provider\Doctrine\Persistence\Event\CreateSchemaListener;
@@ -20,6 +21,7 @@ use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use DH\Auditor\Provider\ProviderInterface;
 use DH\AuditorBundle\Command\ClearActivityCacheCommand;
+use DH\AuditorBundle\Controller\ExportController;
 use DH\AuditorBundle\Controller\ViewerController;
 use DH\AuditorBundle\DependencyInjection\Compiler\DoctrineMiddlewareCompilerPass;
 use DH\AuditorBundle\DependencyInjection\Compiler\RegisterDiffLabelResolversCompilerPass;
@@ -244,6 +246,11 @@ class DHAuditorBundle extends AbstractBundle
             ->tag('console.command', ['command' => 'audit:clean'])
         ;
 
+        $services->set(ExportAuditLogsCommand::class)
+            ->call('setAuditor', [new Reference(Auditor::class)])
+            ->tag('console.command', ['command' => 'audit:export'])
+        ;
+
         $services->set(UpdateSchemaCommand::class)
             ->call('setAuditor', [new Reference(Auditor::class)])
             ->tag('console.command', ['command' => 'audit:schema:update'])
@@ -291,6 +298,11 @@ class DHAuditorBundle extends AbstractBundle
 
     private function loadBundleServices(ServicesConfigurator $services): void
     {
+        // ExportController (uses #[AsController] attribute — always registered)
+        $services->set(ExportController::class)
+            ->autoconfigure()
+        ;
+
         // ViewerController (uses #[AsController] attribute)
         $services->set(ViewerController::class)
             ->args([

--- a/src/Routing/RoutingLoader.php
+++ b/src/Routing/RoutingLoader.php
@@ -30,14 +30,13 @@ final class RoutingLoader extends Loader
             throw new \RuntimeException('Do not add the "audit" loader twice');
         }
 
-        $routeCollection = new RouteCollection();
-        if (Configuration::isViewerEnabledInConfig($this->configuration['viewer'])) {
-            $routeCollection = $this->attributeRouteControllerLoader->load(ViewerController::class);
-        }
+        // Export routes must be added first so /audit/export takes priority over /audit/{entity}.
+        $routeCollection = $this->attributeRouteControllerLoader->load(ExportController::class);
 
-        // Export routes are always registered regardless of viewer.enabled
-        $exportRoutes = $this->attributeRouteControllerLoader->load(ExportController::class);
-        $routeCollection->addCollection($exportRoutes);
+        if (Configuration::isViewerEnabledInConfig($this->configuration['viewer'])) {
+            $viewerRoutes = $this->attributeRouteControllerLoader->load(ViewerController::class);
+            $routeCollection->addCollection($viewerRoutes);
+        }
 
         $this->isLoaded = true;
 

--- a/src/Routing/RoutingLoader.php
+++ b/src/Routing/RoutingLoader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DH\AuditorBundle\Routing;
 
 use DH\Auditor\Provider\Doctrine\Configuration;
+use DH\AuditorBundle\Controller\ExportController;
 use DH\AuditorBundle\Controller\ViewerController;
 use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
 use Symfony\Component\Config\Loader\Loader;
@@ -33,6 +34,10 @@ final class RoutingLoader extends Loader
         if (Configuration::isViewerEnabledInConfig($this->configuration['viewer'])) {
             $routeCollection = $this->attributeRouteControllerLoader->load(ViewerController::class);
         }
+
+        // Export routes are always registered regardless of viewer.enabled
+        $exportRoutes = $this->attributeRouteControllerLoader->load(ExportController::class);
+        $routeCollection->addCollection($exportRoutes);
 
         $this->isLoaded = true;
 

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\AuditorBundle\Tests\Controller;
+
+use DH\Auditor\Provider\Doctrine\DoctrineProvider;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\BlogSchemaSetupTrait;
+use DH\AuditorBundle\Controller\ExportController;
+use DH\AuditorBundle\Helper\UrlHelper;
+use PHPUnit\Framework\Attributes\Small;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+/**
+ * @internal
+ *
+ * @see ExportController
+ */
+#[Small]
+final class ExportControllerTest extends WebTestCase
+{
+    use BlogSchemaSetupTrait;
+
+    private AbstractBrowser $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = self::createClient();
+
+        $this->createAndInitDoctrineProvider();
+        $this->configureEntities();
+        $this->setupEntitySchemas();
+        $this->setupAuditSchemas();
+        $this->setupEntities();
+    }
+
+    public function testExportNdjsonDefaultsAllEntities(): void
+    {
+        $this->client->request('GET', '/audit/export');
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('application/x-ndjson', (string) $response->headers->get('Content-Type'));
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $this->assertNotEmpty($content, 'Response body must not be empty');
+
+        foreach (array_filter(explode("\n", mb_trim($content))) as $line) {
+            $decoded = json_decode($line, true);
+            $this->assertIsArray($decoded, 'Each NDJSON line must decode to an array');
+            $this->assertArrayHasKey('type', $decoded);
+            $this->assertArrayHasKey('object_id', $decoded);
+        }
+    }
+
+    public function testExportJsonFormat(): void
+    {
+        $this->client->request('GET', '/audit/export?format=json');
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('application/json', (string) $response->headers->get('Content-Type'));
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $decoded = json_decode($content, true);
+        $this->assertIsArray($decoded, 'JSON format must return a JSON array');
+        $this->assertNotEmpty($decoded, 'JSON array must not be empty');
+        $this->assertArrayHasKey('type', $decoded[0]);
+    }
+
+    public function testExportCsvFormat(): void
+    {
+        $this->client->request('GET', '/audit/export?format=csv');
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('text/csv', (string) $response->headers->get('Content-Type'));
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $lines = array_filter(explode("\n", mb_trim($content)));
+        $this->assertGreaterThanOrEqual(2, \count($lines), 'CSV must have at least a header row and one data row');
+
+        $header = str_getcsv(array_values($lines)[0], escape: '\\');
+        $this->assertContains('type', $header, 'CSV header must contain "type"');
+        $this->assertContains('object_id', $header, 'CSV header must contain "object_id"');
+    }
+
+    public function testExportWithEntityFilter(): void
+    {
+        $entityParam = UrlHelper::namespaceToParam(Author::class);
+        $this->client->request('GET', '/audit/export?entity='.$entityParam);
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $this->assertNotEmpty($content);
+
+        foreach (array_filter(explode("\n", mb_trim($content))) as $line) {
+            $row = json_decode($line, true);
+            $this->assertIsArray($row);
+            $this->assertArrayHasKey('type', $row);
+            $this->assertArrayHasKey('object_id', $row);
+        }
+    }
+
+    public function testExportAnonymize(): void
+    {
+        $this->client->request('GET', '/audit/export?anonymize=1&format=ndjson');
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $this->assertNotEmpty($content);
+
+        foreach (array_filter(explode("\n", mb_trim($content))) as $line) {
+            $row = json_decode($line, true);
+            $this->assertIsArray($row);
+            $this->assertNull($row['blame_id'], 'blame_id must be null when anonymized');
+            $this->assertNull($row['blame_user'], 'blame_user must be null when anonymized');
+        }
+    }
+
+    public function testExportReturns400ForInvalidFormat(): void
+    {
+        $this->client->request('GET', '/audit/export?format=xml');
+        $this->assertSame(400, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testExportReturns404ForUnknownEntity(): void
+    {
+        $this->client->request('GET', '/audit/export?entity=No-Such-Entity-Class');
+        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testExportReturns403WhenRoleDenied(): void
+    {
+        $this->login(['ROLE_USER']);
+        $entityParam = UrlHelper::namespaceToParam(Author::class);
+        $this->client->request('GET', '/audit/export?entity='.$entityParam);
+
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testContentDispositionHeaderPresent(): void
+    {
+        $this->client->request('GET', '/audit/export');
+        $disposition = $this->client->getResponse()->headers->get('Content-Disposition');
+
+        $this->assertNotNull($disposition);
+        $this->assertStringContainsString('attachment', (string) $disposition);
+        $this->assertStringContainsString('audit-export-', (string) $disposition);
+        $this->assertStringContainsString('.ndjson', (string) $disposition);
+    }
+
+    private function createAndInitDoctrineProvider(): void
+    {
+        $this->provider = self::getContainer()->get(DoctrineProvider::class);
+    }
+
+    private function login(array $roles = []): void
+    {
+        $user = new InMemoryUser(
+            'dark.vador',
+            '$argon2id$v=19$m=65536,t=4,p=1$g1yZVCS0GJ32k2fFqBBtqw$359jLODXkhqVWtD/rf+CjiNz9r/kIvhJlenPBnW851Y',
+            $roles
+        );
+
+        $this->client->loginUser($user);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET /audit/export` endpoint (`ExportController`) that streams audit entries as NDJSON, JSON, or CSV with `Content-Disposition: attachment` and `X-Accel-Buffering: no` for nginx streaming
- Support query parameters: `entity`, `id`, `from`, `to`, `blame_id`, `format` (default: `ndjson`), `anonymize`
- Authorization: for single-entity requests the role check runs before `createQuery()` to avoid leaking entity names to unauthorized callers; bulk exports filter entities by role
- Fix: register export routes before ViewerController in `RoutingLoader` so `/audit/export` is not shadowed by `/audit/{entity}`; explicit throws in `toCsvLine()` instead of disabled `assert()`
- Add 9 integration tests covering all formats, entity filter, anonymization, 400/403/404 error cases, and `Content-Disposition` header

## Test plan

- [ ] `composer agent-test` passes (62 tests)
- [ ] `GET /audit/export` returns valid NDJSON with expected keys
- [ ] `GET /audit/export?format=json` returns valid JSON array
- [ ] `GET /audit/export?format=csv` returns CSV with header row
- [ ] Entity filter, anonymization, and access control work correctly
- [ ] `Content-Disposition` header contains timestamped filename